### PR TITLE
Require name and numeric role for users

### DIFF
--- a/ahorro.sql
+++ b/ahorro.sql
@@ -3,9 +3,11 @@ USE ahorro;
 CREATE TABLE IF NOT EXISTS users (
   id INT AUTO_INCREMENT PRIMARY KEY,
   username VARCHAR(50) NOT NULL UNIQUE,
+  name VARCHAR(100) NOT NULL,
+  role INT NOT NULL,
   password VARCHAR(255) NOT NULL
 );
-INSERT INTO users (username, password) VALUES ('admin', '$2y$12$ezA0Ov0KAUW5PpyPoG6urOnu1B7vKes0onxl4huXVdhIJIW/9HmH.');
+INSERT INTO users (username, name, role, password) VALUES ('admin', 'Administrador', 1, '$2y$12$ezA0Ov0KAUW5PpyPoG6urOnu1B7vKes0onxl4huXVdhIJIW/9HmH.');
 
 CREATE TABLE IF NOT EXISTS slides (
   id INT AUTO_INCREMENT PRIMARY KEY,

--- a/app/controllers/AuthController.php
+++ b/app/controllers/AuthController.php
@@ -13,7 +13,12 @@ class AuthController
             $user = User::findByUsername($username);
             if ($user && password_verify($password, $user['password'])) {
                 $_SESSION['username'] = $username;
-                header('Location: usuarios.php');
+                $_SESSION['role'] = $user['role'];
+                if ($user['role'] === 1) {
+                    header('Location: usuarios.php');
+                } else {
+                    header('Location: index.php');
+                }
                 exit;
             }
             $error = 'Usuario o contraseña incorrectos.';

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -17,16 +17,20 @@ class UserController
                 case 'create':
                     $username = $_POST['username'] ?? '';
                     $password = $_POST['password'] ?? '';
-                    if ($username && $password) {
-                        User::create($username, $password);
+                    $name = $_POST['name'] ?? '';
+                    $role = isset($_POST['role']) ? (int)$_POST['role'] : 0;
+                    if ($username && $password && $name && $role) {
+                        User::create($username, $password, $name, $role);
                     }
                     break;
                 case 'update':
                     $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
                     $username = $_POST['username'] ?? '';
                     $password = $_POST['password'] ?? '';
-                    if ($id && $username) {
-                        User::update($id, $username, $password);
+                    $name = $_POST['name'] ?? '';
+                    $role = isset($_POST['role']) ? (int)$_POST['role'] : 0;
+                    if ($id && $username && $name && $role) {
+                        User::update($id, $username, $name, $role, $password);
                     }
                     break;
                 case 'delete':

--- a/app/views/usuarios.php
+++ b/app/views/usuarios.php
@@ -7,15 +7,17 @@
     </div>
     <table class="table table-striped">
         <thead>
-            <tr><th>ID</th><th>Usuario</th><th>Acciones</th></tr>
+            <tr><th>ID</th><th>Usuario</th><th>Nombre</th><th>Rol</th><th>Acciones</th></tr>
         </thead>
         <tbody>
         <?php foreach ($users as $user): ?>
             <tr>
                 <td><?php echo htmlspecialchars($user['id']); ?></td>
                 <td><?php echo htmlspecialchars($user['username']); ?></td>
+                <td><?php echo htmlspecialchars($user['name']); ?></td>
+                <td><?php echo htmlspecialchars($user['role']); ?></td>
                 <td>
-                    <button class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#editModal" data-id="<?php echo $user['id']; ?>" data-username="<?php echo htmlspecialchars($user['username'], ENT_QUOTES); ?>">Editar</button>
+                    <button class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#editModal" data-id="<?php echo $user['id']; ?>" data-username="<?php echo htmlspecialchars($user['username'], ENT_QUOTES); ?>" data-name="<?php echo htmlspecialchars($user['name'], ENT_QUOTES); ?>" data-role="<?php echo htmlspecialchars($user['role'], ENT_QUOTES); ?>">Editar</button>
                     <form method="post" action="" class="d-inline" onsubmit="return confirm('¿Eliminar usuario?');">
                         <input type="hidden" name="action" value="delete">
                         <input type="hidden" name="id" value="<?php echo $user['id']; ?>">
@@ -41,6 +43,14 @@
         <div class="mb-3">
           <label class="form-label">Usuario</label>
           <input type="text" class="form-control" name="username" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Nombre</label>
+          <input type="text" class="form-control" name="name" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Rol</label>
+          <input type="number" class="form-control" name="role" required>
         </div>
         <div class="mb-3">
           <label class="form-label">Contraseña</label>
@@ -71,6 +81,14 @@
           <input type="text" class="form-control" name="username" id="edit-username" required>
         </div>
         <div class="mb-3">
+          <label class="form-label">Nombre</label>
+          <input type="text" class="form-control" name="name" id="edit-name" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Rol</label>
+          <input type="number" class="form-control" name="role" id="edit-role" required>
+        </div>
+        <div class="mb-3">
           <label class="form-label">Contraseña (dejar en blanco para no cambiar)</label>
           <input type="password" class="form-control" name="password">
         </div>
@@ -89,6 +107,8 @@ editModal.addEventListener('show.bs.modal', function (event) {
   var button = event.relatedTarget;
   document.getElementById('edit-id').value = button.getAttribute('data-id');
   document.getElementById('edit-username').value = button.getAttribute('data-username');
+  document.getElementById('edit-name').value = button.getAttribute('data-name');
+  document.getElementById('edit-role').value = button.getAttribute('data-role');
 });
 </script>
 


### PR DESCRIPTION
## Summary
- store user roles as integers for future role table
- update PHP model, controller, and views to handle numeric roles

## Testing
- `php -l app/models/User.php`
- `php -l app/controllers/UserController.php`
- `php -l app/views/usuarios.php`
- `mysql --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b2598c1ba08326957c1b912f8fe990