### PR TITLE
Add editable database-driven banner section beneath homepage slider

### DIFF
--- a/ahorro.sql
+++ b/ahorro.sql
@@ -20,3 +20,14 @@ CREATE TABLE IF NOT EXISTS slides (
 );
 INSERT INTO slides (title, description, image, link, estado, color) VALUES
 ('Women New Collection', 'Up to 70% off selected Product', 'assets/images/slider/slide-1.jpg', 'shop-grid.html', 1, 1);
+
+CREATE TABLE IF NOT EXISTS banners (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(255) NOT NULL,
+  subtitle VARCHAR(255) NOT NULL,
+  image VARCHAR(255) NOT NULL,
+  link VARCHAR(255) NOT NULL DEFAULT 'shop-grid.html'
+);
+INSERT INTO banners (title, subtitle, image, link) VALUES
+('Office Dress', 'Up to 50% Off', 'assets/images/banner/banner-4.jpg', 'shop-grid.html'),
+('All Products', 'Up to 40% Off', 'assets/images/banner/banner-5.jpg', 'shop-grid.html');

--- a/app/controllers/BannerController.php
+++ b/app/controllers/BannerController.php
@@ -1,0 +1,72 @@
+<?php
+require_once __DIR__ . '/../models/Banner.php';
+
+class BannerController
+{
+    public function handle(): void
+    {
+        session_start();
+        if (!isset($_SESSION['username'])) {
+            header('Location: inicio.php');
+            exit;
+        }
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $action = $_POST['action'] ?? '';
+            switch ($action) {
+                case 'create':
+                    $title = $_POST['title'] ?? '';
+                    $subtitle = $_POST['subtitle'] ?? '';
+                    $link = $_POST['link'] ?? '';
+                    $link = $link ?: 'shop-grid.html';
+                    $image = '';
+                    if (isset($_FILES['image']) && $_FILES['image']['error'] === UPLOAD_ERR_OK) {
+                        $uploadDir = __DIR__ . '/../../assets/images/banner/';
+                        if (!is_dir($uploadDir)) {
+                            mkdir($uploadDir, 0777, true);
+                        }
+                        $filename = time() . '-' . basename($_FILES['image']['name']);
+                        $destination = $uploadDir . $filename;
+                        if (move_uploaded_file($_FILES['image']['tmp_name'], $destination)) {
+                            $image = 'assets/images/banner/' . $filename;
+                        }
+                    }
+                    if ($title && $subtitle && $image) {
+                        Banner::create($title, $subtitle, $image, $link);
+                    }
+                    break;
+                case 'update':
+                    $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+                    $title = $_POST['title'] ?? '';
+                    $subtitle = $_POST['subtitle'] ?? '';
+                    $link = $_POST['link'] ?? '';
+                    $link = $link ?: 'shop-grid.html';
+                    $image = $_POST['current_image'] ?? '';
+                    if (isset($_FILES['image']) && $_FILES['image']['error'] === UPLOAD_ERR_OK) {
+                        $uploadDir = __DIR__ . '/../../assets/images/banner/';
+                        if (!is_dir($uploadDir)) {
+                            mkdir($uploadDir, 0777, true);
+                        }
+                        $filename = time() . '-' . basename($_FILES['image']['name']);
+                        $destination = $uploadDir . $filename;
+                        if (move_uploaded_file($_FILES['image']['tmp_name'], $destination)) {
+                            $image = 'assets/images/banner/' . $filename;
+                        }
+                    }
+                    if ($id && $title && $subtitle && $image) {
+                        Banner::update($id, $title, $subtitle, $image, $link);
+                    }
+                    break;
+                case 'delete':
+                    $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+                    if ($id) {
+                        Banner::delete($id);
+                    }
+                    break;
+            }
+        }
+
+        header('Location: index.php');
+        exit;
+    }
+}

--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../models/Product.php';
 require_once __DIR__ . '/../models/Slide.php';
+require_once __DIR__ . '/../models/Banner.php';
 
 class HomeController
 {
@@ -8,6 +9,7 @@ class HomeController
     {
         $products = Product::all();
         $slides = Slide::all();
+        $banners = Banner::all();
         include __DIR__ . '/../views/home.php';
     }
 }

--- a/app/models/Banner.php
+++ b/app/models/Banner.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../../conexion.php';
+
+class Banner
+{
+    public static function all(): array
+    {
+        $mysqli = obtenerConexion();
+        $result = $mysqli->query('SELECT id, title, subtitle, image, link FROM banners');
+        $banners = $result->fetch_all(MYSQLI_ASSOC);
+        $mysqli->close();
+        return $banners;
+    }
+
+    public static function create(string $title, string $subtitle, string $image, string $link): bool
+    {
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('INSERT INTO banners (title, subtitle, image, link) VALUES (?, ?, ?, ?)');
+        $stmt->bind_param('ssss', $title, $subtitle, $image, $link);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+
+    public static function update(int $id, string $title, string $subtitle, string $image, string $link): bool
+    {
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('UPDATE banners SET title = ?, subtitle = ?, image = ?, link = ? WHERE id = ?');
+        $stmt->bind_param('ssssi', $title, $subtitle, $image, $link, $id);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+
+    public static function delete(int $id): bool
+    {
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('DELETE FROM banners WHERE id = ?');
+        $stmt->bind_param('i', $id);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+}

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -2,7 +2,8 @@
 
 <?php if (isset($_SESSION['username'])): ?>
 <div class="container my-3">
-    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#slideModal">Slide</button>
+    <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#slideModal">Slide</button>
+    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#bannerModal">Banner</button>
 </div>
 <?php endif; ?>
 
@@ -35,6 +36,31 @@
     </div>
 </div>
 <!-- Hero/Intro Slider End -->
+
+<!-- Banner Section Start -->
+<div class="section section-margin">
+    <div class="container">
+        <div class="row mb-n6 overflow-hidden">
+            <?php foreach ($banners as $index => $banner): ?>
+            <div class="col-md-6 col-12 mb-6" data-aos="<?= $index % 2 === 0 ? 'fade-right' : 'fade-left' ?>" data-aos-delay="300">
+                <div class="banner">
+                    <div class="banner-image">
+                        <a href="<?= htmlspecialchars($banner['link']) ?>"><img src="<?= htmlspecialchars($banner['image']) ?>" alt="Banner Image"></a>
+                    </div>
+                    <div class="info">
+                        <div class="small-banner-content">
+                            <h4 class="sub-title"><?= htmlspecialchars($banner['subtitle']) ?></h4>
+                            <h3 class="title"><?= htmlspecialchars($banner['title']) ?></h3>
+                            <a href="<?= htmlspecialchars($banner['link']) ?>" class="btn btn-primary btn-hover-dark btn-sm">Shop Now</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
+    </div>
+</div>
+<!-- Banner Section End -->
 
 <h1>Productos destacados</h1>
 <ul>
@@ -145,6 +171,64 @@
   </div>
 </div>
 <!-- Slide Modal End -->
+<!-- Banner Modal -->
+<div class="modal fade" id="bannerModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-xl">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Banners</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <?php foreach ($banners as $banner): ?>
+        <form id="banner-form-<?= $banner['id'] ?>" method="post" action="banners.php" enctype="multipart/form-data"></form>
+        <?php endforeach; ?>
+        <form id="banner-form-new" method="post" action="banners.php" enctype="multipart/form-data"></form>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Imagen</th>
+              <th>Subtítulo</th>
+              <th>Título</th>
+              <th>Link</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php foreach ($banners as $banner): ?>
+            <tr>
+              <td>
+                <img src="<?= htmlspecialchars($banner['image']) ?>" alt="" class="img-thumbnail mb-1" style="max-width:80px;" id="banner-preview-<?= $banner['id'] ?>">
+                <input type="file" name="image" class="form-control form-control-sm" onchange="previewImage(this,'banner-preview-<?= $banner['id'] ?>')" form="banner-form-<?= $banner['id'] ?>">
+                <input type="hidden" name="current_image" value="<?= htmlspecialchars($banner['image']) ?>" form="banner-form-<?= $banner['id'] ?>">
+              </td>
+              <td><input type="text" name="subtitle" value="<?= htmlspecialchars($banner['subtitle']) ?>" class="form-control" form="banner-form-<?= $banner['id'] ?>"></td>
+              <td><input type="text" name="title" value="<?= htmlspecialchars($banner['title']) ?>" class="form-control" form="banner-form-<?= $banner['id'] ?>"></td>
+              <td><input type="text" name="link" value="<?= htmlspecialchars($banner['link']) ?>" class="form-control" form="banner-form-<?= $banner['id'] ?>"></td>
+              <td>
+                <input type="hidden" name="id" value="<?= $banner['id'] ?>" form="banner-form-<?= $banner['id'] ?>">
+                <button class="btn btn-success btn-sm" name="action" value="update" form="banner-form-<?= $banner['id'] ?>">Guardar</button>
+                <button class="btn btn-danger btn-sm" name="action" value="delete" onclick="return confirm('¿Eliminar?')" form="banner-form-<?= $banner['id'] ?>">Eliminar</button>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+            <tr>
+              <td>
+                <img src="" alt="" class="img-thumbnail mb-1 d-none" style="max-width:80px;" id="banner-preview-new">
+                <input type="file" name="image" class="form-control form-control-sm" onchange="previewImage(this,'banner-preview-new')" form="banner-form-new">
+              </td>
+              <td><input type="text" name="subtitle" class="form-control" placeholder="Subtítulo" form="banner-form-new"></td>
+              <td><input type="text" name="title" class="form-control" placeholder="Título" form="banner-form-new"></td>
+              <td><input type="text" name="link" class="form-control" placeholder="Link" form="banner-form-new"></td>
+              <td><button class="btn btn-primary btn-sm" name="action" value="create" form="banner-form-new">Crear</button></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+<!-- Banner Modal End -->
 <?php endif; ?>
 
 <?php if (isset($_SESSION['username'])): ?>

--- a/banners.php
+++ b/banners.php
@@ -1,0 +1,5 @@
+<?php
+require_once __DIR__ . '/app/controllers/BannerController.php';
+
+$controller = new BannerController();
+$controller->handle();


### PR DESCRIPTION
## Summary
- Store banners in new `banners` table and expose CRUD through Banner model and controller
- Load banners from database on home page and render dynamic banner section
- Provide admin-only modal for updating banner images, titles and links

## Testing
- `php -l app/models/Banner.php`
- `php -l app/controllers/BannerController.php`
- `php -l banners.php`
- `php -l app/controllers/HomeController.php`
- `php -l app/views/home.php`


------
https://chatgpt.com/codex/tasks/task_b_68b2e9b397508326bb8800c85c5e38e1