### PR TITLE
Add provider support for garments

### DIFF
--- a/ahorro.sql
+++ b/ahorro.sql
@@ -49,6 +49,11 @@ CREATE TABLE IF NOT EXISTS categories (
   name VARCHAR(100) NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS providers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS tags (
   id INT AUTO_INCREMENT PRIMARY KEY,
   text VARCHAR(100) NOT NULL,
@@ -73,11 +78,13 @@ CREATE TABLE IF NOT EXISTS garments (
   comment VARCHAR(200) NOT NULL,
   type ENUM('nueva','usada') NOT NULL,
   category_id INT,
+  provider_id INT,
   tag_id INT,
   state_id INT,
   purchase_date DATE,
   sale_date DATE,
   FOREIGN KEY (category_id) REFERENCES categories(id),
+  FOREIGN KEY (provider_id) REFERENCES providers(id),
   FOREIGN KEY (tag_id) REFERENCES tags(id),
   FOREIGN KEY (state_id) REFERENCES states(id)
 );

--- a/app/controllers/PrendaController.php
+++ b/app/controllers/PrendaController.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../models/Garment.php';
 require_once __DIR__ . '/../models/Category.php';
+require_once __DIR__ . '/../models/Provider.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/State.php';
 
@@ -80,6 +81,7 @@ class PrendaController
                     $comment = $_POST['comment'] ?? '';
                     $type = $_POST['type'] ?? 'nueva';
                     $category = isset($_POST['category_id']) ? (int)$_POST['category_id'] : null;
+                    $provider = isset($_POST['provider_id']) ? (int)$_POST['provider_id'] : null;
                     $tag = isset($_POST['tag_id']) && $_POST['tag_id'] !== '' ? (int)$_POST['tag_id'] : null;
                     $state = isset($_POST['state_id']) ? (int)$_POST['state_id'] : null;
                     $purchaseDate = $_POST['purchase_date'] ?? null;
@@ -112,7 +114,7 @@ class PrendaController
                         }
                     }
                     if ($name && $imagePrimary && $imageSecondary) {
-                        Garment::create($name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $tag, $state, $purchaseDate, $saleDate);
+                        Garment::create($name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $provider, $tag, $state, $purchaseDate, $saleDate);
                     }
                     break;
                 case 'update':
@@ -129,6 +131,7 @@ class PrendaController
                     $comment = $_POST['comment'] ?? '';
                     $type = $_POST['type'] ?? 'nueva';
                     $category = isset($_POST['category_id']) ? (int)$_POST['category_id'] : null;
+                    $provider = isset($_POST['provider_id']) ? (int)$_POST['provider_id'] : null;
                     $tag = isset($_POST['tag_id']) && $_POST['tag_id'] !== '' ? (int)$_POST['tag_id'] : null;
                     $state = isset($_POST['state_id']) ? (int)$_POST['state_id'] : null;
                     $purchaseDate = $_POST['purchase_date'] ?? null;
@@ -161,7 +164,7 @@ class PrendaController
                         }
                     }
                     if ($id && $name && $imagePrimary && $imageSecondary) {
-                        Garment::update($id, $name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $tag, $state, $purchaseDate, $saleDate);
+                        Garment::update($id, $name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $provider, $tag, $state, $purchaseDate, $saleDate);
                     }
                     break;
                 case 'delete':
@@ -194,6 +197,25 @@ class PrendaController
                     $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
                     if ($id) {
                         Category::delete($id);
+                    }
+                    break;
+                case 'create_provider':
+                    $name = $_POST['name'] ?? '';
+                    if ($name) {
+                        Provider::create($name);
+                    }
+                    break;
+                case 'update_provider':
+                    $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+                    $name = $_POST['name'] ?? '';
+                    if ($id && $name) {
+                        Provider::update($id, $name);
+                    }
+                    break;
+                case 'delete_provider':
+                    $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+                    if ($id) {
+                        Provider::delete($id);
                     }
                     break;
                 case 'create_tag':
@@ -245,6 +267,7 @@ class PrendaController
 
         $garments = Garment::all();
         $categories = Category::all();
+        $providers = Provider::all();
         $tags = Tag::all();
         $states = State::all();
         include __DIR__ . '/../views/prendas.php';

--- a/app/models/Garment.php
+++ b/app/models/Garment.php
@@ -7,9 +7,10 @@ class Garment
     public static function all(): array
     {
         $mysqli = obtenerConexion();
-        $sql = 'SELECT g.*, c.name AS category_name, t.text AS tag_text, t.color AS tag_color, s.name AS state_name '
+        $sql = 'SELECT g.*, c.name AS category_name, p.name AS provider_name, t.text AS tag_text, t.color AS tag_color, s.name AS state_name '
              . 'FROM garments g '
              . 'LEFT JOIN categories c ON g.category_id = c.id '
+             . 'LEFT JOIN providers p ON g.provider_id = p.id '
              . 'LEFT JOIN tags t ON g.tag_id = t.id '
              . 'LEFT JOIN states s ON g.state_id = s.id';
         $result = $mysqli->query($sql);
@@ -27,22 +28,22 @@ class Garment
         return $garments;
     }
 
-    public static function create(string $name, string $imagePrimary, string $imageSecondary, float $purchase, float $sale, string $code, int $condition, string $size, string $comment, string $type, ?int $category, ?int $tag, ?int $state, ?string $purchaseDate, ?string $saleDate): bool
+    public static function create(string $name, string $imagePrimary, string $imageSecondary, float $purchase, float $sale, string $code, int $condition, string $size, string $comment, string $type, ?int $category, ?int $provider, ?int $tag, ?int $state, ?string $purchaseDate, ?string $saleDate): bool
     {
         $mysqli = obtenerConexion();
-        $stmt = $mysqli->prepare('INSERT INTO garments (name, image_primary, image_secondary, purchase_value, sale_value, unique_code, `condition`, size, comment, type, category_id, tag_id, state_id, purchase_date, sale_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
-        $stmt->bind_param('sssddsisssiiiss', $name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $tag, $state, $purchaseDate, $saleDate);
+        $stmt = $mysqli->prepare('INSERT INTO garments (name, image_primary, image_secondary, purchase_value, sale_value, unique_code, `condition`, size, comment, type, category_id, provider_id, tag_id, state_id, purchase_date, sale_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)');
+        $stmt->bind_param('sssddsisssiiiiss', $name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $provider, $tag, $state, $purchaseDate, $saleDate);
         $success = $stmt->execute();
         $stmt->close();
         $mysqli->close();
         return $success;
     }
 
-    public static function update(int $id, string $name, string $imagePrimary, string $imageSecondary, float $purchase, float $sale, string $code, int $condition, string $size, string $comment, string $type, ?int $category, ?int $tag, ?int $state, ?string $purchaseDate, ?string $saleDate): bool
+    public static function update(int $id, string $name, string $imagePrimary, string $imageSecondary, float $purchase, float $sale, string $code, int $condition, string $size, string $comment, string $type, ?int $category, ?int $provider, ?int $tag, ?int $state, ?string $purchaseDate, ?string $saleDate): bool
     {
         $mysqli = obtenerConexion();
-        $stmt = $mysqli->prepare('UPDATE garments SET name=?, image_primary=?, image_secondary=?, purchase_value=?, sale_value=?, unique_code=?, `condition`=?, size=?, comment=?, type=?, category_id=?, tag_id=?, state_id=?, purchase_date=?, sale_date=? WHERE id=?');
-        $stmt->bind_param('sssddsisssiiissi', $name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $tag, $state, $purchaseDate, $saleDate, $id);
+        $stmt = $mysqli->prepare('UPDATE garments SET name=?, image_primary=?, image_secondary=?, purchase_value=?, sale_value=?, unique_code=?, `condition`=?, size=?, comment=?, type=?, category_id=?, provider_id=?, tag_id=?, state_id=?, purchase_date=?, sale_date=? WHERE id=?');
+        $stmt->bind_param('sssddsisssiiiissi', $name, $imagePrimary, $imageSecondary, $purchase, $sale, $code, $condition, $size, $comment, $type, $category, $provider, $tag, $state, $purchaseDate, $saleDate, $id);
         $success = $stmt->execute();
         $stmt->close();
         $mysqli->close();

--- a/app/models/Provider.php
+++ b/app/models/Provider.php
@@ -1,0 +1,61 @@
+<?php
+require_once __DIR__ . '/../../conexion.php';
+
+class Provider
+{
+    public static function all(): array
+    {
+        $mysqli = obtenerConexion();
+        $sql = 'SELECT p.id, p.name, COUNT(g.id) AS usage_count '
+             . 'FROM providers p LEFT JOIN garments g ON g.provider_id = p.id '
+             . 'GROUP BY p.id, p.name';
+        $result = $mysqli->query($sql);
+        $providers = $result->fetch_all(MYSQLI_ASSOC);
+        $mysqli->close();
+        return $providers;
+    }
+
+    public static function create(string $name): bool
+    {
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('INSERT INTO providers (name) VALUES (?)');
+        $stmt->bind_param('s', $name);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+
+    public static function update(int $id, string $name): bool
+    {
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('UPDATE providers SET name = ? WHERE id = ?');
+        $stmt->bind_param('si', $name, $id);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+
+    public static function delete(int $id): bool
+    {
+        $mysqli = obtenerConexion();
+        $check = $mysqli->prepare('SELECT COUNT(*) FROM garments WHERE provider_id = ?');
+        $check->bind_param('i', $id);
+        $check->execute();
+        $check->bind_result($count);
+        $check->fetch();
+        $check->close();
+        if ($count > 0) {
+            $mysqli->close();
+            return false;
+        }
+        $stmt = $mysqli->prepare('DELETE FROM providers WHERE id = ?');
+        $stmt->bind_param('i', $id);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+}
+?>

--- a/app/views/prendas.php
+++ b/app/views/prendas.php
@@ -6,6 +6,7 @@
         <div>
             <button class="btn btn-success me-2" data-bs-toggle="modal" data-bs-target="#createGarmentModal">Crear Prenda</button>
             <button class="btn btn-secondary me-2" data-bs-toggle="modal" data-bs-target="#categoryModal">Categorías</button>
+            <button class="btn btn-secondary me-2" data-bs-toggle="modal" data-bs-target="#providerModal">Proveedores</button>
             <button class="btn btn-secondary me-2" data-bs-toggle="modal" data-bs-target="#tagModal">Etiquetas</button>
             <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#stateModal">Estados</button>
         </div>
@@ -19,6 +20,7 @@
                 <th>Venta</th>
                 <th>Tipo</th>
                 <th>Categoría</th>
+                <th>Proveedor</th>
                 <th>Etiqueta</th>
                 <th>Estado</th>
                 <th>Acciones</th>
@@ -33,6 +35,7 @@
                 <td><?= htmlspecialchars($garment['sale_value']) ?></td>
                 <td><?= htmlspecialchars($garment['type']) ?></td>
                 <td><?= htmlspecialchars($garment['category_name']) ?></td>
+                <td><?= htmlspecialchars($garment['provider_name']) ?></td>
                 <td>
                     <?php if (!empty($garment['tag_id'])): ?>
                     <span class="badge" style="background-color: <?= htmlspecialchars($garment['tag_bg_color']) ?>; color: <?= htmlspecialchars($garment['tag_text_color']) ?>;">
@@ -68,6 +71,7 @@
                         data-comment="<?= htmlspecialchars($garment['comment'], ENT_QUOTES) ?>"
                         data-type="<?= htmlspecialchars($garment['type'], ENT_QUOTES) ?>"
                         data-category="<?= $garment['category_id'] ?>"
+                        data-provider="<?= $garment['provider_id'] ?>"
                         data-tag="<?= $garment['tag_id'] ?>"
                         data-state="<?= $garment['state_id'] ?>"
                         data-pdate="<?= $garment['purchase_date'] ?>"
@@ -145,6 +149,15 @@
               <option value="">Seleccione</option>
               <?php foreach ($categories as $cat): ?>
               <option value="<?= $cat['id'] ?>"><?= htmlspecialchars($cat['name']) ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="col-md-6">
+            <label class="form-label">Proveedor</label>
+            <select class="form-select" name="provider_id">
+              <option value="">Seleccione</option>
+              <?php foreach ($providers as $prov): ?>
+              <option value="<?= $prov['id'] ?>"><?= htmlspecialchars($prov['name']) ?></option>
               <?php endforeach; ?>
             </select>
           </div>
@@ -253,6 +266,15 @@
             </select>
           </div>
           <div class="col-md-6">
+            <label class="form-label">Proveedor</label>
+            <select class="form-select" name="provider_id" id="edit-provider">
+              <option value="">Seleccione</option>
+              <?php foreach ($providers as $prov): ?>
+              <option value="<?= $prov['id'] ?>"><?= htmlspecialchars($prov['name']) ?></option>
+              <?php endforeach; ?>
+            </select>
+          </div>
+          <div class="col-md-6">
             <label class="form-label">Etiqueta</label>
               <select class="form-select" name="tag_id" id="edit-tag">
                 <option value="">Ninguna</option>
@@ -318,6 +340,50 @@
             <form method="post" action="" onsubmit="return confirm('¿Eliminar categoría?');">
               <input type="hidden" name="action" value="delete_category">
               <input type="hidden" name="id" value="<?= $cat['id'] ?>">
+              <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+            </form>
+            <?php endif; ?>
+          </li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Provider Modal -->
+<div class="modal fade" id="providerModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Proveedores</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form class="mb-3" method="post" action="">
+          <input type="hidden" name="action" value="create_provider">
+          <label class="form-label">Nombre</label>
+          <div class="input-group">
+            <input type="text" class="form-control" name="name" required>
+            <button type="submit" class="btn btn-primary">Guardar</button>
+          </div>
+        </form>
+        <ul class="list-group">
+          <?php foreach ($providers as $prov): ?>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <form class="d-flex flex-grow-1 me-2" method="post" action="">
+              <input type="hidden" name="action" value="update_provider">
+              <input type="hidden" name="id" value="<?= $prov['id'] ?>">
+              <input type="text" name="name" class="form-control me-2" value="<?= htmlspecialchars($prov['name']) ?>">
+              <button type="submit" class="btn btn-sm btn-primary">Guardar</button>
+            </form>
+            <?php if ($prov['usage_count'] == 0): ?>
+            <form method="post" action="" onsubmit="return confirm('¿Eliminar proveedor?');">
+              <input type="hidden" name="action" value="delete_provider">
+              <input type="hidden" name="id" value="<?= $prov['id'] ?>">
               <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
             </form>
             <?php endif; ?>
@@ -457,6 +523,7 @@ editModal.addEventListener('show.bs.modal', function (event) {
   document.getElementById('edit-comment').value = button.getAttribute('data-comment');
   document.getElementById('edit-type').value = button.getAttribute('data-type');
   document.getElementById('edit-category').value = button.getAttribute('data-category');
+  document.getElementById('edit-provider').value = button.getAttribute('data-provider');
   document.getElementById('edit-tag').value = button.getAttribute('data-tag');
   document.getElementById('edit-state').value = button.getAttribute('data-state');
   document.getElementById('edit-pdate').value = button.getAttribute('data-pdate');


### PR DESCRIPTION
## Summary
- add Provider model and database schema
- show and manage garment providers
- allow assigning provider to garments

## Testing
- `php -l app/models/Provider.php`
- `php -l app/models/Garment.php`
- `php -l app/controllers/PrendaController.php`
- `php -l app/views/prendas.php`


------
https://chatgpt.com/codex/tasks/task_b_68b38de232fc832693f083a1a55b8f57