### PR TITLE
Start sessions on public controllers to preserve login across navigation

### DIFF
--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -9,6 +9,9 @@ class HomeController
 {
     public function index(): void
     {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
         $slides = Slide::all();
         $banners = Banner::all();
         $features = Feature::all();

--- a/app/controllers/NuevaController.php
+++ b/app/controllers/NuevaController.php
@@ -6,6 +6,9 @@ class NuevaController
 {
     public function index(): void
     {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
         $categoryId = isset($_GET['category']) ? (int)$_GET['category'] : null;
         $sort = $_GET['sort'] ?? null;
         $perPage = isset($_GET['perPage']) ? (int)$_GET['perPage'] : 9;

--- a/app/controllers/UsadaController.php
+++ b/app/controllers/UsadaController.php
@@ -6,6 +6,9 @@ class UsadaController
 {
     public function index(): void
     {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
         $categoryId = isset($_GET['category']) ? (int)$_GET['category'] : null;
         $sort = $_GET['sort'] ?? null;
         $perPage = isset($_GET['perPage']) ? (int)$_GET['perPage'] : 9;


### PR DESCRIPTION
## Summary
- Start PHP sessions in HomeController to make session data available across the site
- Initiate sessions in NuevaController and UsadaController so login remains active when browsing products

## Testing
- `php -l app/controllers/HomeController.php`
- `php -l app/controllers/NuevaController.php`
- `php -l app/controllers/UsadaController.php`


------
https://chatgpt.com/codex/tasks/task_b_68b74467012883268ac971160bd9b869