### PR TITLE
Add robust garment detail page with asset helper

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,0 +1,7 @@
+<?php
+include __DIR__ . '/app/views/layout/header.php';
+?>
+<div class="container my-5">
+    <h1>Producto no encontrado</h1>
+</div>
+<?php include __DIR__ . '/app/views/layout/footer.php'; ?>

--- a/500.php
+++ b/500.php
@@ -1,0 +1,7 @@
+<?php
+include __DIR__ . '/app/views/layout/header.php';
+?>
+<div class="container my-5">
+    <h1>Error interno, intente luego</h1>
+</div>
+<?php include __DIR__ . '/app/views/layout/footer.php'; ?>

--- a/app/models/Garment.php
+++ b/app/models/Garment.php
@@ -156,6 +156,26 @@ class Garment
         return $success;
     }
 
+
+    public static function find(int $id): ?array
+    {
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('SELECT g.*, c.name AS category_name, t.text AS tag_text, t.color AS tag_color FROM garments g LEFT JOIN categories c ON g.category_id = c.id LEFT JOIN tags t ON g.tag_id = t.id WHERE g.id = ? LIMIT 1');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $garment = $result->fetch_assoc();
+        $stmt->close();
+        $mysqli->close();
+        if ($garment && !empty($garment['tag_color'])) {
+            $palette = Tag::palette();
+            if (isset($palette[$garment['tag_color']])) {
+                [$garment['tag_bg_color'], $garment['tag_text_color']] = $palette[$garment['tag_color']];
+            }
+        }
+        return $garment ?: null;
+    }
+
     public static function updateState(int $id, ?int $stateId): bool
     {
         $mysqli = obtenerConexion();

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -121,8 +121,8 @@
                                         <div class="product product-border-left mb-10" data-aos="fade-up" data-aos-delay="200">
                                             <div class="thumb">
                                                 <a href="#" class="image" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>">
-                                              <img class="first-image" src="<?= htmlspecialchars($garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
-                                              <img class="second-image" src="<?= htmlspecialchars(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                              <img class="first-image" src="<?= htmlspecialchars(asset($garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                              <img class="second-image" src="<?= htmlspecialchars(asset(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
                                                 </a>
                                                 <?php if (!empty($garment['tag_text'])): ?>
                                                 <span class="badges">
@@ -149,7 +149,9 @@
                                                 $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                 $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                 ?>
-                                                <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>                                            </div>
+                                                <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
+                                                <?php $detailUrl = asset('prendas.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                                <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
@@ -169,8 +171,8 @@
                                         <div class="product product-border-left mb-10" data-aos="fade-up" data-aos-delay="200">
                                             <div class="thumb">
                                                 <a href="#" class="image" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>">
-                                                <img class="first-image" src="<?= htmlspecialchars($garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
-                                                    <img class="second-image" src="<?= htmlspecialchars(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                                <img class="first-image" src="<?= htmlspecialchars(asset($garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                                    <img class="second-image" src="<?= htmlspecialchars(asset(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
                                                 </a>
                                                 <?php if (!empty($garment['tag_text'])): ?>
                                                 <span class="badges">
@@ -198,7 +200,9 @@
                                                 $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                 $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                 ?>
-                                               <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>                                            </div>
+                                               <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
+                                                <?php $detailUrl = asset('prendas.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                                <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
@@ -228,7 +232,7 @@
                             <div class="swiper-container">
                                 <div class="swiper-wrapper">
                                     <a class="swiper-slide" href="#">
-                                    <img class="w-100" src="<?= htmlspecialchars($garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product">
+                                    <img class="w-100" src="<?= htmlspecialchars(asset($garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product">
                                     </a>
                                     <?php if (!empty($garment['image_secondary'])): ?>
                                     <a class="swiper-slide" href="#">
@@ -272,6 +276,8 @@
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a class="btn btn-outline-dark btn-hover-primary" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <?php $detailUrl = asset('prendas.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                    <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
                                 </div>
                             </div>
                         </div>

--- a/app/views/layout/footer.php
+++ b/app/views/layout/footer.php
@@ -122,22 +122,23 @@
             <i class="arrow-bottom fa fa-long-arrow-up"></i>
         </a>
         <!-- Scroll Top End -->
-    <!-- Vendors JS -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-        <script src="./assets/js/vendor/jquery-3.6.0.min.js"></script>
-        <script src="./assets/js/vendor/jquery-migrate-3.3.2.min.js"></script>
-        <script src="./assets/js/vendor/modernizr-3.11.2.min.js"></script>
+            <!-- Vendors JS -->
+        <script src="<?= asset('assets/js/vendor/jquery-3.6.0.min.js') ?>" defer></script>
+        <script>window.jQuery && (jQuery.migrateMute = true, jQuery.migrateTrace = false);</script>
+        <script src="<?= asset('assets/js/vendor/jquery-migrate-3.3.2.min.js') ?>" defer></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+        <script src="<?= asset('assets/js/vendor/modernizr-3.11.2.min.js') ?>" defer></script>
         <!-- Plugins JS -->
-        <script src="./assets/js/plugins/countdown.min.js"></script>
-        <script src="./assets/js/plugins/aos.min.js"></script>
-        <script src="./assets/js/plugins/swiper-bundle.min.js"></script>
-        <script src="./assets/js/plugins/nice-select.min.js"></script>
-        <script src="./assets/js/plugins/jquery.ajaxchimp.min.js"></script>
-        <script src="./assets/js/plugins/jquery-ui.min.js"></script>
-        <script src="./assets/js/plugins/lightgallery-all.min.js"></script>
-        <script src="./assets/js/plugins/thia-sticky-sidebar.min.js"></script>
+        <script src="<?= asset('assets/js/plugins/countdown.min.js') ?>" defer></script>
+        <script src="<?= asset('assets/js/plugins/aos.min.js') ?>" defer></script>
+        <script src="<?= asset('assets/js/plugins/swiper-bundle.min.js') ?>" defer></script>
+        <script src="<?= asset('assets/js/plugins/nice-select.min.js') ?>" defer></script>
+        <script src="<?= asset('assets/js/plugins/jquery.ajaxchimp.min.js') ?>" defer></script>
+        <script src="<?= asset('assets/js/plugins/jquery-ui.min.js') ?>" defer></script>
+        <script src="<?= asset('assets/js/plugins/lightgallery-all.min.js') ?>" defer></script>
+        <script src="<?= asset('assets/js/plugins/thia-sticky-sidebar.min.js') ?>" defer></script>
         <!--Main JS-->
-        <script src="./assets/js/main.js"></script>
+        <script src="<?= asset('assets/js/main.js') ?>" defer></script>
     </body>
     
     </html>

--- a/app/views/layout/header.php
+++ b/app/views/layout/header.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../../bootstrap.php';
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
@@ -11,29 +12,26 @@ $menu = (function () {
 echo "<!DOCTYPE html>\n";
 ?>
 <html lang="es">
-
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>El armario del ahorro</title>
-    
-    <link rel="icon" href="/assets/favicon.ico">
-    <link rel="preload" href="/assets/fonts/fontAwesome/fontawesome-webfont.woff2" as="font" type="font/woff2" crossorigin>
 
+    <link rel="icon" href="<?= asset('assets/favicon.ico') ?>">
+    <link rel="preload" href="<?= asset('assets/fonts/fontAwesome/fontawesome-webfont.woff2?v=4.7.0') ?>" as="font" type="font/woff2" crossorigin>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="stylesheet" href="./assets/css/vendor/fontawesome.min.css">
-    <link rel="stylesheet" href="./assets/css/vendor/pe-icon-7-stroke.min.css">
-    <link rel="stylesheet" href="./assets/css/plugins/swiper-bundle.min.css" />
-    <link rel="stylesheet" href="./assets/css/plugins/animate.min.css" />
-    <link rel="stylesheet" href="./assets/css/plugins/aos.min.css" />
-    <link rel="stylesheet" href="./assets/css/plugins/nice-select.min.css" />
-    <link rel="stylesheet" href="./assets/css/plugins/jquery-ui.min.css" />
-    <link rel="stylesheet" href="./assets/css/plugins/lightgallery.min.css" />
-    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="<?= asset('assets/css/vendor/fontawesome.min.css') ?>">
+    <link rel="stylesheet" href="<?= asset('assets/css/vendor/pe-icon-7-stroke.min.css') ?>">
+    <link rel="stylesheet" href="<?= asset('assets/css/plugins/swiper-bundle.min.css') ?>" />
+    <link rel="stylesheet" href="<?= asset('assets/css/plugins/animate.min.css') ?>" />
+    <link rel="stylesheet" href="<?= asset('assets/css/plugins/aos.min.css') ?>" />
+    <link rel="stylesheet" href="<?= asset('assets/css/plugins/nice-select.min.css') ?>" />
+    <link rel="stylesheet" href="<?= asset('assets/css/plugins/jquery-ui.min.css') ?>" />
+    <link rel="stylesheet" href="<?= asset('assets/css/plugins/lightgallery.min.css') ?>" />
+    <link rel="stylesheet" href="<?= asset('assets/css/style.css') ?>" />
 </head>
-
 
 <body>
     <div class="header section">
@@ -55,7 +53,7 @@ echo "<!DOCTYPE html>\n";
 
                     <!-- Header Top Message Start -->
                     <div class="col">
-                        <p class="header-top-message"><b>Productos en oferta: </b>. Revise nuestra lista de productos de 2da mano <a href="./usada.php?perPage=9&sort=new">Ver productos</a></p>
+                        <p class="header-top-message"><b>Productos en oferta: </b>. Revise nuestra lista de productos de 2da mano <a href="<?= asset('usada.php') ?>?perPage=9&amp;sort=new">Ver productos</a></p>
                     </div>
                     <!-- Header Top Message End -->
 
@@ -73,7 +71,7 @@ echo "<!DOCTYPE html>\n";
                         <!-- Header Logo Start -->
                         <div class="col-xl-2 col-6">
                             <div class="header-logo">
-                                <a href="./index.php"><img src="./assets/images/logo/logo.png" alt="Site Logo" /></a>
+                                <a href="<?= asset('index.php') ?>"><img src="<?= asset('assets/images/logo/logo.png') ?>" alt="Site Logo" /></a>
                             </div>
                         </div>
                         <!-- Header Logo End -->
@@ -87,7 +85,7 @@ echo "<!DOCTYPE html>\n";
                             </div>
                         </div>
                         <!-- Header Menu End -->
- <!-- Header Action Start -->
+                        <!-- Header Action Start -->
                         <div class="col-xl-2 col-6">
                             <div class="header-actions">
 
@@ -128,7 +126,6 @@ echo "<!DOCTYPE html>\n";
                         </ul>
                     </nav>
                 </div>
-              
 
                 <!-- Contact Links/Social Links Start -->
                 <div class="mt-auto">

--- a/app/views/layout/menu.php
+++ b/app/views/layout/menu.php
@@ -13,7 +13,7 @@ if (isset($_SESSION['username'])) {
 }
 
 foreach ($menuItems as $item) {
-    $href = htmlspecialchars($item['href'], ENT_QUOTES, 'UTF-8');
+    $href = htmlspecialchars(asset($item['href']), ENT_QUOTES, 'UTF-8');
     $label = htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8');
     echo "    <li class=\"has-children\"><a href=\"$href\">$label </a></li>\n";
 }

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -72,8 +72,8 @@
                         <div class="product-inner">
                             <div class="thumb">
                                 <a href="#" class="image" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>">
-                                     <img class="first-image" src="<?= htmlspecialchars($garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
-                                    <img class="second-image" src="<?= htmlspecialchars(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                     <img class="first-image" src="<?= htmlspecialchars(asset($garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                    <img class="second-image" src="<?= htmlspecialchars(asset(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
                                 </a>
                                 <?php if (!empty($garment['tag_text'])): ?>
                                 <span class="badges">
@@ -117,6 +117,8 @@
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
+                                    <?php $detailUrl = asset('prendas.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>
                                 </div>
                             </div>
                         </div>
@@ -230,7 +232,7 @@
                             <div class="swiper-container">
                                 <div class="swiper-wrapper">
                                     <a class="swiper-slide" href="#">
-                                        <img class="w-100" src="<?= htmlspecialchars($garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product">
+                                        <img class="w-100" src="<?= htmlspecialchars(asset($garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product">
                                     </a>
                                     <?php if (!empty($garment['image_secondary'])): ?>
                                     <a class="swiper-slide" href="#">
@@ -302,6 +304,8 @@
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a class="btn btn-outline-dark btn-hover-primary" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <?php $detailUrl = asset('prendas.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                    <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
                                 </div>
                             </div>
                             <!-- Cart & Wishlist Button End -->

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -1,0 +1,36 @@
+<?php include __DIR__ . '/layout/header.php'; ?>
+<div class="section section-margin">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-6">
+        <?php
+        $basePath = __DIR__ . '/../../';
+        $primary = $garment['image_primary'] ?? '';
+        if ($primary && (filter_var($primary, FILTER_VALIDATE_URL) || is_file($basePath . $primary))): ?>
+            <img class="img-fluid mb-3" src="<?= htmlspecialchars(asset($primary), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($garment['name'], ENT_QUOTES, 'UTF-8'); ?>">
+        <?php endif; ?>
+        <?php
+        $secondary = $garment['image_secondary'] ?? '';
+        if ($secondary && (filter_var($secondary, FILTER_VALIDATE_URL) || is_file($basePath . $secondary))): ?>
+            <img class="img-fluid" src="<?= htmlspecialchars(asset($secondary), ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($garment['name'], ENT_QUOTES, 'UTF-8'); ?>">
+        <?php endif; ?>
+      </div>
+      <div class="col-md-6">
+        <h1><?= htmlspecialchars($garment['name'], ENT_QUOTES, 'UTF-8'); ?></h1>
+        <?php if (!empty($garment['unique_code'])): ?>
+        <p>Código: <?= htmlspecialchars($garment['unique_code'], ENT_QUOTES, 'UTF-8'); ?></p>
+        <?php endif; ?>
+        <?php if (!empty($garment['comment'])): ?>
+        <p><?= htmlspecialchars($garment['comment'], ENT_QUOTES, 'UTF-8'); ?></p>
+        <?php endif; ?>
+        <p>Precio: $<?= number_format((float)$garment['sale_value'], 2); ?></p>
+        <?php
+          $waMessage = 'Por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
+          $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+        ?>
+        <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary">Preguntar</a>
+      </div>
+    </div>
+  </div>
+</div>
+<?php include __DIR__ . '/layout/footer.php'; ?>

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -72,8 +72,8 @@
                         <div class="product-inner">
                             <div class="thumb">
                                 <a href="#" class="image" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>">
-                                    <img class="first-image" src="<?= htmlspecialchars($garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
-                                    <img class="second-image" src="<?= htmlspecialchars(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                    <img class="first-image" src="<?= htmlspecialchars(asset($garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
+                                    <img class="second-image" src="<?= htmlspecialchars(asset(!empty($garment['image_secondary']) ? $garment['image_secondary'] : $garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product" />
                                 </a>
                                 <?php if (!empty($garment['tag_text'])): ?>
                                 <span class="badges">
@@ -118,6 +118,8 @@
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
+                                    <?php $detailUrl = asset('prendas.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>
                                 </div>
                             </div>
                         </div>
@@ -231,7 +233,7 @@
                             <div class="swiper-container">
                                 <div class="swiper-wrapper">
                                     <a class="swiper-slide" href="#">
-                                        <img class="w-100" src="<?= htmlspecialchars($garment['image_primary'], ENT_QUOTES, 'UTF-8'); ?>" alt="Product">
+                                        <img class="w-100" src="<?= htmlspecialchars(asset($garment['image_primary']), ENT_QUOTES, 'UTF-8'); ?>" alt="Product">
                                     </a>
                                     <?php if (!empty($garment['image_secondary'])): ?>
                                     <a class="swiper-slide" href="#">
@@ -303,6 +305,8 @@
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a class="btn btn-outline-dark btn-hover-primary" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <?php $detailUrl = asset('prendas.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                    <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
                                 </div>
                             </div>
                             <!-- Cart & Wishlist Button End -->

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+if (!defined('BASE_URL')) {
+    define('BASE_URL', '');
+}
+function asset(string $path): string
+{
+    return rtrim(BASE_URL, '/') . '/' . ltrim($path, '/');
+}

--- a/prendas.php
+++ b/prendas.php
@@ -1,5 +1,23 @@
 <?php
-require_once __DIR__ . '/app/controllers/PrendaController.php';
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/app/models/Garment.php';
 
-$controller = new PrendaController();
-$controller->handle();
+try {
+    $idRaw = filter_input(INPUT_GET, 'id', FILTER_SANITIZE_STRING);
+    if (!$idRaw) {
+        header('Location: ' . asset('usada.php'), true, 302);
+        exit;
+    }
+    $id = (int)$idRaw;
+    $garment = Garment::find($id);
+    if (!$garment) {
+        http_response_code(404);
+        include __DIR__ . '/404.php';
+        exit;
+    }
+    include __DIR__ . '/app/views/prenda_detalle.php';
+} catch (Throwable $e) {
+    error_log($e->getMessage() . "\n", 3, __DIR__ . '/php-error.log');
+    http_response_code(500);
+    include __DIR__ . '/500.php';
+}


### PR DESCRIPTION
## Summary
- implement BASE_URL asset helper and update layout to use absolute asset paths
- add product detail flow with sanitized id, error handling, and 404/500 pages
- link listings to detail page and improve JS ordering

## Testing
- `php -l bootstrap.php app/views/layout/header.php app/views/layout/menu.php app/views/layout/footer.php 404.php 500.php prendas.php app/models/Garment.php app/views/prenda_detalle.php app/views/home.php app/views/nueva.php app/views/usada.php`
- `php -l app/views/layout/header.php`

------
https://chatgpt.com/codex/tasks/task_b_68b7904fef688326b9564c7a3fcbd055