### PR TITLE
Start session globally for persistent login

### DIFF
--- a/app/controllers/AuthController.php
+++ b/app/controllers/AuthController.php
@@ -5,7 +5,6 @@ class AuthController
 {
     public function login(): void
     {
-        session_start();
         $error = '';
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $username = $_POST['username'] ?? '';
@@ -28,7 +27,6 @@ class AuthController
 
     public function logout(): void
     {
-        session_start();
         session_unset();
         session_destroy();
         header('Location: index.php');

--- a/app/controllers/BannerController.php
+++ b/app/controllers/BannerController.php
@@ -55,7 +55,6 @@ class BannerController
 
     public function handle(): void
     {
-        session_start();
         if (!isset($_SESSION['username'])) {
             header('Location: inicio.php');
             exit;

--- a/app/controllers/FeatureController.php
+++ b/app/controllers/FeatureController.php
@@ -5,7 +5,6 @@ class FeatureController
 {
     public function handle(): void
     {
-        session_start();
         if (!isset($_SESSION['username'])) {
             header('Location: inicio.php');
             exit;

--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -9,9 +9,6 @@ class HomeController
 {
     public function index(): void
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $slides = Slide::all();
         $banners = Banner::all();
         $features = Feature::all();

--- a/app/controllers/NuevaController.php
+++ b/app/controllers/NuevaController.php
@@ -6,9 +6,6 @@ class NuevaController
 {
     public function index(): void
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $categoryId = isset($_GET['category']) ? (int)$_GET['category'] : null;
         $sort = $_GET['sort'] ?? null;
         $perPage = isset($_GET['perPage']) ? (int)$_GET['perPage'] : 9;

--- a/app/controllers/PrendaController.php
+++ b/app/controllers/PrendaController.php
@@ -59,7 +59,6 @@ class PrendaController
 
     public function handle(): void
     {
-        session_start();
         if (!isset($_SESSION['username'])) {
             header('Location: inicio.php');
             exit;

--- a/app/controllers/SlideController.php
+++ b/app/controllers/SlideController.php
@@ -5,7 +5,6 @@ class SlideController
 {
     public function handle(): void
     {
-        session_start();
         if (!isset($_SESSION['username'])) {
             header('Location: inicio.php');
             exit;

--- a/app/controllers/UsadaController.php
+++ b/app/controllers/UsadaController.php
@@ -6,9 +6,6 @@ class UsadaController
 {
     public function index(): void
     {
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
         $categoryId = isset($_GET['category']) ? (int)$_GET['category'] : null;
         $sort = $_GET['sort'] ?? null;
         $perPage = isset($_GET['perPage']) ? (int)$_GET['perPage'] : 9;

--- a/app/controllers/UserController.php
+++ b/app/controllers/UserController.php
@@ -5,7 +5,6 @@ class UserController
 {
     public function index(): void
     {
-        session_start();
         if (!isset($_SESSION['username'])) {
             header('Location: inicio.php');
             exit;

--- a/app/views/layout/header.php
+++ b/app/views/layout/header.php
@@ -1,8 +1,5 @@
 <?php
 require_once __DIR__ . '/../../../bootstrap.php';
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
 header('Content-Type: text/html; charset=UTF-8');
 $menu = (function () {
     ob_start();

--- a/banners.php
+++ b/banners.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/BannerController.php';
 
 $controller = new BannerController();

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -11,6 +11,7 @@ if (!defined('BASE_URL')) {
 $cookiePath = BASE_URL === '' ? '/' : BASE_URL;
 if (session_status() === PHP_SESSION_NONE) {
     session_set_cookie_params(['path' => $cookiePath]);
+    session_start();
 }
 
 function asset(string $path): string

--- a/features.php
+++ b/features.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/FeatureController.php';
 
 $controller = new FeatureController();

--- a/slides.php
+++ b/slides.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/SlideController.php';
 
 $controller = new SlideController();

--- a/usuarios.php
+++ b/usuarios.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/UserController.php';
 
 $controller = new UserController();


### PR DESCRIPTION
## Summary
- Start PHP session in `bootstrap.php` and set cookie path
- Remove redundant `session_start` calls in controllers and header
- Ensure entry scripts require `bootstrap.php` to maintain session across pages

## Testing
- `php -l app/controllers/AuthController.php app/controllers/BannerController.php app/controllers/FeatureController.php app/controllers/HomeController.php app/controllers/NuevaController.php app/controllers/PrendaController.php app/controllers/SlideController.php app/controllers/UsadaController.php app/controllers/UserController.php app/views/layout/header.php banners.php bootstrap.php features.php slides.php usuarios.php`


------
https://chatgpt.com/codex/tasks/task_b_68b7aadd45d08326899883f759469961