### PR TITLE
Remove stray PHP closing tags to prevent blank page

### DIFF
--- a/app/controllers/PrendaController.php
+++ b/app/controllers/PrendaController.php
@@ -278,4 +278,4 @@ class PrendaController
         include __DIR__ . '/../views/prendas.php';
     }
 }
-?>
+

--- a/app/models/Category.php
+++ b/app/models/Category.php
@@ -70,4 +70,4 @@ class Category
         return $success;
     }
 }
-?>
+

--- a/app/models/Garment.php
+++ b/app/models/Garment.php
@@ -204,4 +204,4 @@ class Garment
         return $success;
     }
 }
-?>
+

--- a/app/models/Provider.php
+++ b/app/models/Provider.php
@@ -58,4 +58,4 @@ class Provider
         return $success;
     }
 }
-?>
+

--- a/app/models/State.php
+++ b/app/models/State.php
@@ -71,4 +71,4 @@ class State
         return $success;
     }
 }
-?>
+

--- a/app/models/Tag.php
+++ b/app/models/Tag.php
@@ -79,5 +79,5 @@ class Tag
         return $success;
     }
 }
-?>
+
 


### PR DESCRIPTION
## Summary
- Drop closing PHP tags from PrendaController and related models to avoid emitting whitespace before headers.

## Testing
- `php -l app/controllers/PrendaController.php`
- `php -l app/models/Category.php`
- `php -l app/models/Garment.php`
- `php -l app/models/Provider.php`
- `php -l app/models/State.php`
- `php -l app/models/Tag.php`


------
https://chatgpt.com/codex/tasks/task_b_68b7b5a333788326abddfde6e09e57a0