### PR TITLE
Add server-side guest cart

### DIFF
--- a/ahorro.sql
+++ b/ahorro.sql
@@ -98,3 +98,21 @@ CREATE TABLE IF NOT EXISTS cart_items (
   UNIQUE KEY uniq_cart (session_id, garment_id),
   FOREIGN KEY (garment_id) REFERENCES garments(id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  buyer_name VARCHAR(100) NOT NULL,
+  phone VARCHAR(30) NOT NULL,
+  payment_method VARCHAR(20) NOT NULL,
+  status ENUM('pending','confirmed','rejected') DEFAULT 'pending',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  order_id INT NOT NULL,
+  garment_id INT NOT NULL,
+  quantity INT NOT NULL DEFAULT 1,
+  FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
+  FOREIGN KEY (garment_id) REFERENCES garments(id)
+);

--- a/ahorro.sql
+++ b/ahorro.sql
@@ -99,6 +99,18 @@ CREATE TABLE IF NOT EXISTS cart_items (
   FOREIGN KEY (garment_id) REFERENCES garments(id) ON DELETE CASCADE
 );
 
+DROP TRIGGER IF EXISTS cart_item_after_delete;
+DELIMITER //
+CREATE TRIGGER cart_item_after_delete
+AFTER DELETE ON cart_items
+FOR EACH ROW
+BEGIN
+  IF (SELECT COUNT(*) FROM cart_items WHERE garment_id = OLD.garment_id) = 0 THEN
+    UPDATE garments SET tag_id = NULL WHERE id = OLD.garment_id;
+  END IF;
+END//
+DELIMITER ;
+
 CREATE TABLE IF NOT EXISTS orders (
   id INT AUTO_INCREMENT PRIMARY KEY,
   buyer_name VARCHAR(100) NOT NULL,

--- a/ahorro.sql
+++ b/ahorro.sql
@@ -88,3 +88,13 @@ CREATE TABLE IF NOT EXISTS garments (
   FOREIGN KEY (tag_id) REFERENCES tags(id),
   FOREIGN KEY (state_id) REFERENCES states(id)
 );
+
+CREATE TABLE IF NOT EXISTS cart_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  session_id VARCHAR(64) NOT NULL,
+  garment_id INT NOT NULL,
+  quantity INT NOT NULL DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_cart (session_id, garment_id),
+  FOREIGN KEY (garment_id) REFERENCES garments(id) ON DELETE CASCADE
+);

--- a/app/controllers/AuthController.php
+++ b/app/controllers/AuthController.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../models/User.php';
+require_once __DIR__ . '/../models/Cart.php';
 
 class AuthController
 {
@@ -27,6 +28,7 @@ class AuthController
 
     public function logout(): void
     {
+        Cart::clear();
         session_unset();
         session_destroy();
         header('Location: index.php');

--- a/app/controllers/CartController.php
+++ b/app/controllers/CartController.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../models/Cart.php';
+
+class CartController
+{
+    public function index(): void
+    {
+        $items = Cart::items();
+        include __DIR__ . '/../views/cart.php';
+    }
+
+    public function add(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $qtyRaw = filter_input(INPUT_POST, 'quantity', FILTER_SANITIZE_NUMBER_INT);
+        $id = (int)$idRaw;
+        $quantity = $qtyRaw !== null ? (int)$qtyRaw : 1;
+        if ($id > 0) {
+            Cart::add($id, $quantity);
+        }
+        header('Location: ' . asset('cart.php'), true, 302);
+        exit;
+    }
+
+    public function remove(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $id = (int)$idRaw;
+        if ($id > 0) {
+            Cart::remove($id);
+        }
+        header('Location: ' . asset('cart.php'), true, 302);
+        exit;
+    }
+}

--- a/app/controllers/CartController.php
+++ b/app/controllers/CartController.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../models/Cart.php';
+require_once __DIR__ . '/../models/Order.php';
 
 class CartController
 {
@@ -30,6 +31,20 @@ class CartController
             Cart::remove($id);
         }
         header('Location: ' . asset('cart.php'), true, 302);
+        exit;
+    }
+
+    public function checkout(): void
+    {
+        $name = trim(filter_input(INPUT_POST, 'name', FILTER_SANITIZE_STRING));
+        $phone = trim(filter_input(INPUT_POST, 'phone', FILTER_SANITIZE_STRING));
+        $payment = filter_input(INPUT_POST, 'payment', FILTER_SANITIZE_STRING);
+        $items = Cart::items();
+        if ($name !== '' && $phone !== '' && $payment && !empty($items)) {
+            Order::create($name, $phone, $payment, $items);
+            Cart::clear(false);
+        }
+        header('Location: ' . asset('index.php'), true, 302);
         exit;
     }
 }

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__ . '/../models/Order.php';
+
+class PedidoController
+{
+    public function index(): void
+    {
+        $orders = Order::all();
+        foreach ($orders as &$order) {
+            $order['items'] = Order::items((int)$order['id']);
+        }
+        include __DIR__ . '/../views/pedidos.php';
+    }
+
+    public function confirm(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $id = (int)$idRaw;
+        if ($id > 0) {
+            Order::confirm($id);
+        }
+        header('Location: ' . asset('pedidos.php'), true, 302);
+        exit;
+    }
+
+    public function reject(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $id = (int)$idRaw;
+        if ($id > 0) {
+            Order::reject($id);
+        }
+        header('Location: ' . asset('pedidos.php'), true, 302);
+        exit;
+    }
+}

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -6,8 +6,8 @@ class PedidoController
     public function index(): void
     {
         $orders = Order::all();
-        foreach ($orders as &$order) {
-            $order['items'] = Order::items((int)$order['id']);
+        foreach ($orders as $index => $order) {
+            $orders[$index]['items'] = Order::items((int)$order['id']);
         }
         include __DIR__ . '/../views/pedidos.php';
     }

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -5,10 +5,13 @@ class PedidoController
 {
     public function index(): void
     {
-        $orders = Order::all();
+        $status = filter_input(INPUT_GET, 'status', FILTER_SANITIZE_STRING);
+        $statusFilter = in_array($status, ['pending', 'confirmed', 'rejected'], true) ? $status : null;
+        $orders = Order::all($statusFilter);
         foreach ($orders as $index => $order) {
             $orders[$index]['items'] = Order::items((int)$order['id']);
         }
+        $currentStatus = $statusFilter ?? '';
         include __DIR__ . '/../views/pedidos.php';
     }
 

--- a/app/models/Cart.php
+++ b/app/models/Cart.php
@@ -95,4 +95,23 @@ class Cart
             }
         }
     }
+
+    public static function purgeExpired(): void
+    {
+        $mysqli = obtenerConexion();
+        $res = $mysqli->query("SELECT id, garment_id FROM cart_items WHERE created_at < (NOW() - INTERVAL 1 HOUR)");
+        if ($res) {
+            $rows = $res->fetch_all(MYSQLI_ASSOC);
+            $res->close();
+            foreach ($rows as $row) {
+                Garment::releaseReservation((int)$row['garment_id']);
+                $del = $mysqli->prepare('DELETE FROM cart_items WHERE id=?');
+                $id = (int)$row['id'];
+                $del->bind_param('i', $id);
+                $del->execute();
+                $del->close();
+            }
+        }
+        $mysqli->close();
+    }
 }

--- a/app/models/Cart.php
+++ b/app/models/Cart.php
@@ -28,7 +28,7 @@ class Cart
     {
         $sessionId = self::getSessionId();
         $mysqli = obtenerConexion();
-        $stmt = $mysqli->prepare('SELECT ci.id, ci.quantity, g.name, g.sale_value FROM cart_items ci JOIN garments g ON ci.garment_id = g.id WHERE ci.session_id = ?');
+        $stmt = $mysqli->prepare('SELECT ci.id, ci.quantity, ci.garment_id, g.name, g.sale_value, g.image_primary FROM cart_items ci JOIN garments g ON ci.garment_id = g.id WHERE ci.session_id = ?');
         $stmt->bind_param('s', $sessionId);
         $stmt->execute();
         $result = $stmt->get_result();

--- a/app/models/Cart.php
+++ b/app/models/Cart.php
@@ -78,4 +78,21 @@ class Cart
         $mysqli->close();
         return (int)$count;
     }
+
+    public static function clear(bool $release = true): void
+    {
+        $sessionId = self::getSessionId();
+        $items = $release ? self::items() : [];
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('DELETE FROM cart_items WHERE session_id=?');
+        $stmt->bind_param('s', $sessionId);
+        $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        if ($release) {
+            foreach ($items as $item) {
+                Garment::releaseReservation((int)$item['garment_id']);
+            }
+        }
+    }
 }

--- a/app/models/Cart.php
+++ b/app/models/Cart.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../../conexion.php';
+require_once __DIR__ . '/Garment.php';
 
 class Cart
 {
@@ -21,6 +22,9 @@ class Cart
         $success = $stmt->execute();
         $stmt->close();
         $mysqli->close();
+        if ($success) {
+            Garment::markReserved($garmentId);
+        }
         return $success;
     }
 
@@ -42,11 +46,22 @@ class Cart
     {
         $sessionId = self::getSessionId();
         $mysqli = obtenerConexion();
+
+        $find = $mysqli->prepare('SELECT garment_id FROM cart_items WHERE id=? AND session_id=?');
+        $find->bind_param('is', $id, $sessionId);
+        $find->execute();
+        $find->bind_result($garmentId);
+        $find->fetch();
+        $find->close();
+
         $stmt = $mysqli->prepare('DELETE FROM cart_items WHERE id=? AND session_id=?');
         $stmt->bind_param('is', $id, $sessionId);
         $success = $stmt->execute();
         $stmt->close();
         $mysqli->close();
+        if ($success && $garmentId) {
+            Garment::releaseReservation($garmentId);
+        }
         return $success;
     }
 

--- a/app/models/Cart.php
+++ b/app/models/Cart.php
@@ -104,12 +104,12 @@ class Cart
             $rows = $res->fetch_all(MYSQLI_ASSOC);
             $res->close();
             foreach ($rows as $row) {
-                Garment::releaseReservation((int)$row['garment_id']);
                 $del = $mysqli->prepare('DELETE FROM cart_items WHERE id=?');
                 $id = (int)$row['id'];
                 $del->bind_param('i', $id);
                 $del->execute();
                 $del->close();
+                Garment::releaseReservation((int)$row['garment_id']);
             }
         }
         $mysqli->close();

--- a/app/models/Cart.php
+++ b/app/models/Cart.php
@@ -1,0 +1,66 @@
+<?php
+require_once __DIR__ . '/../../conexion.php';
+
+class Cart
+{
+    private static function getSessionId(): string
+    {
+        if (empty($_SESSION['cart_session'])) {
+            $_SESSION['cart_session'] = bin2hex(random_bytes(16));
+        }
+        return $_SESSION['cart_session'];
+    }
+
+    public static function add(int $garmentId, int $quantity = 1): bool
+    {
+        $sessionId = self::getSessionId();
+        $quantity = max(1, $quantity);
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('INSERT INTO cart_items (session_id, garment_id, quantity) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE quantity = quantity + VALUES(quantity)');
+        $stmt->bind_param('sii', $sessionId, $garmentId, $quantity);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+
+    public static function items(): array
+    {
+        $sessionId = self::getSessionId();
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('SELECT ci.id, ci.quantity, g.name, g.sale_value FROM cart_items ci JOIN garments g ON ci.garment_id = g.id WHERE ci.session_id = ?');
+        $stmt->bind_param('s', $sessionId);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $items = $result->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        $mysqli->close();
+        return $items;
+    }
+
+    public static function remove(int $id): bool
+    {
+        $sessionId = self::getSessionId();
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('DELETE FROM cart_items WHERE id=? AND session_id=?');
+        $stmt->bind_param('is', $id, $sessionId);
+        $success = $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
+        return $success;
+    }
+
+    public static function count(): int
+    {
+        $sessionId = self::getSessionId();
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('SELECT COALESCE(SUM(quantity),0) FROM cart_items WHERE session_id=?');
+        $stmt->bind_param('s', $sessionId);
+        $stmt->execute();
+        $stmt->bind_result($count);
+        $stmt->fetch();
+        $stmt->close();
+        $mysqli->close();
+        return (int)$count;
+    }
+}

--- a/app/models/Garment.php
+++ b/app/models/Garment.php
@@ -196,6 +196,26 @@ class Garment
         return $success;
     }
 
+    public static function markSold(int $id): bool
+    {
+        $mysqli = obtenerConexion();
+        $tagStmt = $mysqli->prepare("SELECT id FROM tags WHERE LOWER(text)='vendido' LIMIT 1");
+        $tagStmt->execute();
+        $tagStmt->bind_result($tagId);
+        $tagStmt->fetch();
+        $tagStmt->close();
+        if (empty($tagId)) {
+            $mysqli->close();
+            return false;
+        }
+        $upd = $mysqli->prepare('UPDATE garments SET tag_id=? WHERE id=?');
+        $upd->bind_param('ii', $tagId, $id);
+        $success = $upd->execute();
+        $upd->close();
+        $mysqli->close();
+        return $success;
+    }
+
     public static function releaseReservation(int $id): void
     {
         $mysqli = obtenerConexion();

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -49,7 +49,7 @@ class Order
     public static function items(int $orderId): array
     {
         $mysqli = obtenerConexion();
-        $stmt = $mysqli->prepare('SELECT oi.garment_id, oi.quantity, g.name FROM order_items oi JOIN garments g ON oi.garment_id = g.id WHERE oi.order_id = ?');
+        $stmt = $mysqli->prepare('SELECT oi.garment_id, oi.quantity, g.name, g.unique_code, g.image_primary, g.sale_value FROM order_items oi JOIN garments g ON oi.garment_id = g.id WHERE oi.order_id = ?');
         $stmt->bind_param('i', $orderId);
         $stmt->execute();
         $result = $stmt->get_result();

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -1,0 +1,80 @@
+<?php
+require_once __DIR__ . '/../../conexion.php';
+require_once __DIR__ . '/Garment.php';
+
+class Order
+{
+    public static function create(string $name, string $phone, string $payment, array $items): int
+    {
+        $mysqli = obtenerConexion();
+        $mysqli->begin_transaction();
+        $stmt = $mysqli->prepare('INSERT INTO orders (buyer_name, phone, payment_method) VALUES (?, ?, ?)');
+        $stmt->bind_param('sss', $name, $phone, $payment);
+        $stmt->execute();
+        $orderId = $stmt->insert_id;
+        $stmt->close();
+
+        $itemStmt = $mysqli->prepare('INSERT INTO order_items (order_id, garment_id, quantity) VALUES (?, ?, ?)');
+        foreach ($items as $item) {
+            $garmentId = (int)$item['garment_id'];
+            $qty = (int)$item['quantity'];
+            $itemStmt->bind_param('iii', $orderId, $garmentId, $qty);
+            $itemStmt->execute();
+        }
+        $itemStmt->close();
+        $mysqli->commit();
+        $mysqli->close();
+        return $orderId;
+    }
+
+    public static function all(): array
+    {
+        $mysqli = obtenerConexion();
+        $result = $mysqli->query('SELECT id, buyer_name, phone, payment_method, status FROM orders ORDER BY id DESC');
+        $orders = $result->fetch_all(MYSQLI_ASSOC);
+        $result->close();
+        $mysqli->close();
+        return $orders;
+    }
+
+    public static function items(int $orderId): array
+    {
+        $mysqli = obtenerConexion();
+        $stmt = $mysqli->prepare('SELECT oi.garment_id, oi.quantity, g.name FROM order_items oi JOIN garments g ON oi.garment_id = g.id WHERE oi.order_id = ?');
+        $stmt->bind_param('i', $orderId);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $items = $result->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        $mysqli->close();
+        return $items;
+    }
+
+    public static function confirm(int $orderId): void
+    {
+        $items = self::items($orderId);
+        foreach ($items as $item) {
+            Garment::markSold((int)$item['garment_id']);
+        }
+        $mysqli = obtenerConexion();
+        $upd = $mysqli->prepare("UPDATE orders SET status='confirmed' WHERE id=?");
+        $upd->bind_param('i', $orderId);
+        $upd->execute();
+        $upd->close();
+        $mysqli->close();
+    }
+
+    public static function reject(int $orderId): void
+    {
+        $items = self::items($orderId);
+        foreach ($items as $item) {
+            Garment::releaseReservation((int)$item['garment_id']);
+        }
+        $mysqli = obtenerConexion();
+        $upd = $mysqli->prepare("UPDATE orders SET status='rejected' WHERE id=?");
+        $upd->bind_param('i', $orderId);
+        $upd->execute();
+        $upd->close();
+        $mysqli->close();
+    }
+}

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -27,12 +27,21 @@ class Order
         return $orderId;
     }
 
-    public static function all(): array
+    public static function all(?string $status = null): array
     {
         $mysqli = obtenerConexion();
-        $result = $mysqli->query('SELECT id, buyer_name, phone, payment_method, status FROM orders ORDER BY id DESC');
-        $orders = $result->fetch_all(MYSQLI_ASSOC);
-        $result->close();
+        if ($status && in_array($status, ['pending', 'confirmed', 'rejected'], true)) {
+            $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status FROM orders WHERE status = ? ORDER BY id DESC');
+            $stmt->bind_param('s', $status);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $orders = $result->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+        } else {
+            $result = $mysqli->query('SELECT id, buyer_name, phone, payment_method, status FROM orders ORDER BY id DESC');
+            $orders = $result->fetch_all(MYSQLI_ASSOC);
+            $result->close();
+        }
         $mysqli->close();
         return $orders;
     }

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -1,48 +1,100 @@
 <?php include __DIR__ . '/layout/header.php'; ?>
 <div class="section section-margin">
   <div class="container">
-    <h1>Carrito</h1>
     <?php if (empty($items)): ?>
       <p>Tu carrito está vacío.</p>
     <?php else: ?>
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Producto</th>
-            <th>Cantidad</th>
-            <th>Precio</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <?php foreach ($items as $item): ?>
-            <tr>
-              <td><?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?></td>
-              <td><?= (int)$item['quantity']; ?></td>
-              <td>$<?= number_format((float)$item['sale_value'] * $item['quantity'], 2); ?></td>
-              <td>
-                <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
-                  <input type="hidden" name="action" value="remove">
-                  <input type="hidden" name="id" value="<?= (int)$item['id']; ?>">
-                  <button class="btn btn-sm btn-danger" type="submit">Eliminar</button>
-                </form>
-              </td>
-            </tr>
-          <?php endforeach; ?>
-        </tbody>
-      </table>
-      <p class="text-end">
-        <?php
-        $total = array_reduce(
+      <div class="row">
+        <div class="col-12">
+          <div class="cart-table table-responsive">
+            <table class="table table-bordered">
+              <thead>
+                <tr>
+                  <th class="pro-thumbnail">Imagen</th>
+                  <th class="pro-title">Producto</th>
+                  <th class="pro-price">Precio</th>
+                  <th class="pro-quantity">Cantidad</th>
+                  <th class="pro-subtotal">Sub Total</th>
+                  <th class="pro-remove">Eliminar</th>
+                </tr>
+              </thead>
+              <tbody>
+                <?php foreach ($items as $item): ?>
+                  <tr>
+                    <td class="pro-thumbnail">
+                      <?php
+                        $basePath = __DIR__ . '/../../';
+                        $img = $item['image_primary'] ?? '';
+                        $imgSrc = '';
+                        if ($img && (filter_var($img, FILTER_VALIDATE_URL) || is_file($basePath . $img))) {
+                          $imgSrc = asset($img);
+                        }
+                      ?>
+                      <?php if ($imgSrc): ?>
+                        <a href="<?= htmlspecialchars(asset('prenda.php?id=' . (int)$item['garment_id']), ENT_QUOTES, 'UTF-8'); ?>">
+                          <img class="img-fluid" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
+                        </a>
+                      <?php endif; ?>
+                    </td>
+                    <td class="pro-title">
+                      <a href="<?= htmlspecialchars(asset('prenda.php?id=' . (int)$item['garment_id']), ENT_QUOTES, 'UTF-8'); ?>">
+                        <?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>
+                      </a>
+                    </td>
+                    <td class="pro-price"><span>$<?= number_format((float)$item['sale_value'], 2); ?></span></td>
+                    <td class="pro-quantity"><span><?= (int)$item['quantity']; ?></span></td>
+                    <td class="pro-subtotal"><span>$<?= number_format((float)$item['sale_value'] * $item['quantity'], 2); ?></span></td>
+                    <td class="pro-remove">
+                      <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
+                        <input type="hidden" name="action" value="remove">
+                        <input type="hidden" name="id" value="<?= (int)$item['id']; ?>">
+                        <button type="submit" class="btn btn-link p-0"><i class="pe-7s-trash"></i></button>
+                      </form>
+                    </td>
+                  </tr>
+                <?php endforeach; ?>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <?php
+        $subtotal = array_reduce(
           $items,
           function ($carry, $i) {
             return $carry + $i['sale_value'] * $i['quantity'];
           },
           0
         );
-        ?>
-        Total: $<?= number_format($total, 2); ?>
-      </p>
+        $shipping = 0;
+        $total = $subtotal + $shipping;
+      ?>
+      <div class="row">
+        <div class="col-lg-5 ms-auto col-custom">
+          <div class="cart-calculator-wrapper">
+            <div class="cart-calculate-items">
+              <h3 class="title">Valor total</h3>
+              <div class="table-responsive">
+                <table class="table">
+                  <tr>
+                    <td>Sub Total</td>
+                    <td>$<?= number_format($subtotal, 2); ?></td>
+                  </tr>
+                  <tr>
+                    <td>Envio</td>
+                    <td>$<?= number_format($shipping, 2); ?></td>
+                  </tr>
+                  <tr class="total">
+                    <td>Total</td>
+                    <td class="total-amount">$<?= number_format($total, 2); ?></td>
+                  </tr>
+                </table>
+              </div>
+            </div>
+            <a href="#" class="btn btn-dark btn-hover-primary rounded-0 w-100">Verificar</a>
+          </div>
+        </div>
+      </div>
     <?php endif; ?>
   </div>
 </div>

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -79,11 +79,65 @@
                 </table>
               </div>
             </div>
-            <a href="#" class="btn btn-dark btn-hover-primary rounded-0 w-100">Confirmar pedido</a>
+            <button type="button" class="btn btn-dark btn-hover-primary rounded-0 w-100" data-bs-toggle="modal" data-bs-target="#checkoutModal">Confirmar pedido</button>
           </div>
         </div>
       </div>
     <?php endif; ?>
   </div>
 </div>
+<?php if (!empty($items)): ?>
+<div class="modal fade" id="checkoutModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form class="modal-content" method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
+      <input type="hidden" name="action" value="checkout">
+      <div class="modal-header">
+        <h5 class="modal-title">Resumen de compra</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <ul class="list-group mb-3">
+          <?php foreach ($items as $item): ?>
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?> x<?= (int)$item['quantity']; ?>
+            <span>$<?= number_format($item['sale_value'] * $item['quantity'], 2); ?></span>
+          </li>
+          <?php endforeach; ?>
+          <li class="list-group-item d-flex justify-content-between">
+            <strong>Total</strong>
+            <strong>$<?= number_format($total, 2); ?></strong>
+          </li>
+        </ul>
+        <div class="mb-3">
+          <label class="form-label">Nombre</label>
+          <input type="text" name="name" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Teléfono</label>
+          <input type="text" name="phone" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Método de pago</label>
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="payment" id="payCard" value="Tarjeta" required>
+            <label class="form-check-label" for="payCard">Tarjeta de crédito</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="payment" id="payTransfer" value="Transferencia" required>
+            <label class="form-check-label" for="payTransfer">Transferencia</label>
+          </div>
+          <div class="form-check">
+            <input class="form-check-input" type="radio" name="payment" id="payCash" value="Efectivo" required>
+            <label class="form-check-label" for="payCash">Efectivo</label>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
+        <button type="submit" class="btn btn-primary">Enviar</button>
+      </div>
+    </form>
+  </div>
+</div>
+<?php endif; ?>
 <?php include __DIR__ . '/layout/footer.php'; ?>

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -1,0 +1,40 @@
+<?php include __DIR__ . '/layout/header.php'; ?>
+<div class="section section-margin">
+  <div class="container">
+    <h1>Carrito</h1>
+    <?php if (empty($items)): ?>
+      <p>Tu carrito está vacío.</p>
+    <?php else: ?>
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Producto</th>
+            <th>Cantidad</th>
+            <th>Precio</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <?php foreach ($items as $item): ?>
+            <tr>
+              <td><?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?></td>
+              <td><?= (int)$item['quantity']; ?></td>
+              <td>$<?= number_format((float)$item['sale_value'] * $item['quantity'], 2); ?></td>
+              <td>
+                <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
+                  <input type="hidden" name="action" value="remove">
+                  <input type="hidden" name="id" value="<?= (int)$item['id']; ?>">
+                  <button class="btn btn-sm btn-danger" type="submit">Eliminar</button>
+                </form>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </tbody>
+      </table>
+      <p class="text-end">
+        Total: $<?= number_format(array_reduce($items, fn($carry, $i) => $carry + $i['sale_value'] * $i['quantity'], 0), 2); ?>
+      </p>
+    <?php endif; ?>
+  </div>
+</div>
+<?php include __DIR__ . '/layout/footer.php'; ?>

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -81,7 +81,7 @@
                 </table>
               </div>
             </div>
-            <a href="#" class="btn btn-dark btn-hover-primary rounded-0 w-100">Verificar</a>
+            <a href="#" class="btn btn-dark btn-hover-primary rounded-0 w-100">Confirmar pedido</a>
           </div>
         </div>
       </div>

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -4,6 +4,9 @@
     <?php if (empty($items)): ?>
       <p>Tu carrito está vacío.</p>
     <?php else: ?>
+      <div class="alert alert-warning" role="alert">
+        Si en una hora no confirmas la compra, el carrito se vacía automáticamente.
+      </div>
       <div class="row">
         <div class="col-12">
           <div class="cart-table">

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -31,9 +31,7 @@
                           }
                         ?>
                         <?php if ($imgSrc): ?>
-                          <a href="<?= htmlspecialchars(asset('prenda.php?id=' . (int)$item['garment_id']), ENT_QUOTES, 'UTF-8'); ?>">
-                            <img class="img-fluid" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
-                          </a>
+                          <img class="img-thumbnail" style="width: 60px;" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
                         <?php endif; ?>
                       </td>
                       <td class="pro-title">

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -32,7 +32,16 @@
         </tbody>
       </table>
       <p class="text-end">
-        Total: $<?= number_format(array_reduce($items, fn($carry, $i) => $carry + $i['sale_value'] * $i['quantity'], 0), 2); ?>
+        <?php
+        $total = array_reduce(
+          $items,
+          function ($carry, $i) {
+            return $carry + $i['sale_value'] * $i['quantity'];
+          },
+          0
+        );
+        ?>
+        Total: $<?= number_format($total, 2); ?>
       </p>
     <?php endif; ?>
   </div>

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -59,15 +59,13 @@
         </div>
       </div>
       <?php
-        $subtotal = array_reduce(
+        $total = array_reduce(
           $items,
           function ($carry, $i) {
             return $carry + $i['sale_value'] * $i['quantity'];
           },
           0
         );
-        $shipping = 0;
-        $total = $subtotal + $shipping;
       ?>
       <div class="row">
         <div class="col-lg-5 ms-auto col-custom">
@@ -76,14 +74,6 @@
               <h3 class="title">Valor total</h3>
               <div class="table-responsive">
                 <table class="table">
-                  <tr>
-                    <td>Sub Total</td>
-                    <td>$<?= number_format($subtotal, 2); ?></td>
-                  </tr>
-                  <tr>
-                    <td>Envio</td>
-                    <td>$<?= number_format($shipping, 2); ?></td>
-                  </tr>
                   <tr class="total">
                     <td>Total</td>
                     <td class="total-amount">$<?= number_format($total, 2); ?></td>

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -6,55 +6,55 @@
     <?php else: ?>
       <div class="row">
         <div class="col-12">
-          <div class="cart-table table-responsive">
-            <table class="table table-bordered">
-              <thead>
-                <tr>
-                  <th class="pro-thumbnail">Imagen</th>
-                  <th class="pro-title">Producto</th>
-                  <th class="pro-price">Precio</th>
-                  <th class="pro-quantity">Cantidad</th>
-                  <th class="pro-subtotal">Sub Total</th>
-                  <th class="pro-remove">Eliminar</th>
-                </tr>
-              </thead>
-              <tbody>
-                <?php foreach ($items as $item): ?>
+          <div class="cart-table">
+            <div class="table-responsive">
+              <table class="table table-bordered">
+                <thead>
                   <tr>
-                    <td class="pro-thumbnail">
-                      <?php
-                        $basePath = __DIR__ . '/../../';
-                        $img = $item['image_primary'] ?? '';
-                        $imgSrc = '';
-                        if ($img && (filter_var($img, FILTER_VALIDATE_URL) || is_file($basePath . $img))) {
-                          $imgSrc = asset($img);
-                        }
-                      ?>
-                      <?php if ($imgSrc): ?>
-                        <a href="<?= htmlspecialchars(asset('prenda.php?id=' . (int)$item['garment_id']), ENT_QUOTES, 'UTF-8'); ?>">
-                          <img class="img-fluid" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
-                        </a>
-                      <?php endif; ?>
-                    </td>
-                    <td class="pro-title">
-                      <a href="<?= htmlspecialchars(asset('prenda.php?id=' . (int)$item['garment_id']), ENT_QUOTES, 'UTF-8'); ?>">
-                        <?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>
-                      </a>
-                    </td>
-                    <td class="pro-price"><span>$<?= number_format((float)$item['sale_value'], 2); ?></span></td>
-                    <td class="pro-quantity"><span><?= (int)$item['quantity']; ?></span></td>
-                    <td class="pro-subtotal"><span>$<?= number_format((float)$item['sale_value'] * $item['quantity'], 2); ?></span></td>
-                    <td class="pro-remove">
-                      <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
-                        <input type="hidden" name="action" value="remove">
-                        <input type="hidden" name="id" value="<?= (int)$item['id']; ?>">
-                        <button type="submit" class="btn btn-link p-0"><i class="pe-7s-trash"></i></button>
-                      </form>
-                    </td>
+                    <th class="pro-thumbnail">Imagen</th>
+                    <th class="pro-title">Producto</th>
+                    <th class="pro-price">Precio</th>
+                    <th class="pro-quantity">Cantidad</th>
+                    <th class="pro-remove">Eliminar</th>
                   </tr>
-                <?php endforeach; ?>
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  <?php foreach ($items as $item): ?>
+                    <tr>
+                      <td class="pro-thumbnail">
+                        <?php
+                          $basePath = __DIR__ . '/../../';
+                          $img = $item['image_primary'] ?? '';
+                          $imgSrc = '';
+                          if ($img && (filter_var($img, FILTER_VALIDATE_URL) || is_file($basePath . $img))) {
+                            $imgSrc = asset($img);
+                          }
+                        ?>
+                        <?php if ($imgSrc): ?>
+                          <a href="<?= htmlspecialchars(asset('prenda.php?id=' . (int)$item['garment_id']), ENT_QUOTES, 'UTF-8'); ?>">
+                            <img class="img-fluid" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
+                          </a>
+                        <?php endif; ?>
+                      </td>
+                      <td class="pro-title">
+                        <a href="<?= htmlspecialchars(asset('prenda.php?id=' . (int)$item['garment_id']), ENT_QUOTES, 'UTF-8'); ?>">
+                          <?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>
+                        </a>
+                      </td>
+                      <td class="pro-price"><span>$<?= number_format((float)$item['sale_value'], 2); ?></span></td>
+                      <td class="pro-quantity"><span><?= (int)$item['quantity']; ?></span></td>
+                      <td class="pro-remove">
+                        <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
+                          <input type="hidden" name="action" value="remove">
+                          <input type="hidden" name="id" value="<?= (int)$item['id']; ?>">
+                          <button type="submit" class="btn btn-link p-0"><i class="pe-7s-trash"></i></button>
+                        </form>
+                      </td>
+                    </tr>
+                  <?php endforeach; ?>
+                </tbody>
+              </table>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -142,16 +142,22 @@
                                                     </span>
                                                     <span class="rating-num">(<?= round($garment['condition']); ?>/100)</span>
                                                 </span>
-                                                <span class="price">
-                                                    <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
-                                                </span>
-                                                <?php
-                                                $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
-                                                $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
-                                                ?>
-                                                <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
-                                                <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
+                                                  <span class="price">
+                                                      <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
+                                                  </span>
+                                                  <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                                      <input type="hidden" name="action" value="add">
+                                                      <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                                      <input type="hidden" name="quantity" value="1">
+                                                      <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                                  </form>
+                                                  <?php
+                                                  $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
+                                                  $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                                  ?>
+                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
+                                                  <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
@@ -193,16 +199,22 @@
                                                     </span>
                                                     <span class="rating-num">(<?= round($garment['condition']); ?>/100)</span>
                                                 </span>
-                                                <span class="price">
-                                                    <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
-                                                </span>
-                                                <?php
-                                                $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
-                                                $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
-                                                ?>
-                                               <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
-                                                <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
+                                                  <span class="price">
+                                                      <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
+                                                  </span>
+                                                  <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                                      <input type="hidden" name="action" value="add">
+                                                      <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                                      <input type="hidden" name="quantity" value="1">
+                                                      <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                                  </form>
+                                                  <?php
+                                                  $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
+                                                  $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                                  ?>
+                                                 <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
+                                                  <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
@@ -271,11 +283,17 @@
                             <?php endif; ?>
                             <div class="cart-wishlist-btn pb-4 mb-n3">
                                 <div class="add-to_cart mb-3">
+                                    <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                        <input type="hidden" name="action" value="add">
+                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                        <input type="hidden" name="quantity" value="1">
+                                        <button type="submit" class="btn btn-dark btn-hover-primary">Agregar al carrito</button>
+                                    </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-outline-dark btn-hover-primary" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <a class="btn btn-outline-dark btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
                                 </div>

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -149,15 +149,15 @@
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
-                                                      <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                                      <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                                   </form>
                                                   <?php
                                                   $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
-                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
+                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>                                            </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
@@ -206,15 +206,15 @@
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
-                                                      <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                                      <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                                   </form>
                                                   <?php
                                                   $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
-                                                 <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
+                                                 <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>                                            </div>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>                                            </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
@@ -287,15 +287,15 @@
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-dark btn-hover-primary">Agregar al carrito</button>
+                                        <button type="submit" class="btn btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-outline-dark btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <a class="btn btn-info btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-help1"></i></a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
+                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-look"></i></a>
                                 </div>
                             </div>
                         </div>

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -145,17 +145,26 @@
                                                   <span class="price">
                                                       <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
                                                   </span>
+                                                  <?php
+                                                  $tag = strtolower($garment['tag_text'] ?? '');
+                                                  $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+                                                  $showAsk  = $tag !== 'vendido';
+                                                  ?>
+                                                  <?php if ($showCart): ?>
                                                   <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
                                                       <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                                   </form>
+                                                  <?php endif; ?>
+                                                  <?php if ($showAsk): ?>
                                                   <?php
                                                   $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
                                                   <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
+                                                  <?php endif; ?>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                                   <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>                                            </div>
                                         </div>
@@ -202,17 +211,26 @@
                                                   <span class="price">
                                                       <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
                                                   </span>
+                                                  <?php
+                                                  $tag = strtolower($garment['tag_text'] ?? '');
+                                                  $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+                                                  $showAsk  = $tag !== 'vendido';
+                                                  ?>
+                                                  <?php if ($showCart): ?>
                                                   <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
                                                       <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                                   </form>
+                                                  <?php endif; ?>
+                                                  <?php if ($showAsk): ?>
                                                   <?php
                                                   $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
+                                                  <?php endif; ?>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                                   <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>                                            </div>
                                         </div>
@@ -281,23 +299,32 @@
                                 </div>
                             </div>
                             <?php endif; ?>
-                            <div class="cart-wishlist-btn pb-4 mb-n3">
-                                <div class="add-to_cart mb-3">
-                                    <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
-                                        <input type="hidden" name="action" value="add">
-                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
-                                        <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
-                                    </form>
-                                    <?php
-                                    $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
-                                    $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
-                                    ?>
-                                    <a class="btn btn-info btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-help1"></i></a>
-                                    <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-look"></i></a>
+                                <?php
+                                $tag = strtolower($garment['tag_text'] ?? '');
+                                $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+                                $showAsk  = $tag !== 'vendido';
+                                ?>
+                                <div class="cart-wishlist-btn pb-4 mb-n3">
+                                    <div class="add-to_cart mb-3">
+                                        <?php if ($showCart): ?>
+                                        <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                            <input type="hidden" name="action" value="add">
+                                            <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                            <input type="hidden" name="quantity" value="1">
+                                            <button type="submit" class="btn btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
+                                        </form>
+                                        <?php endif; ?>
+                                        <?php if ($showAsk): ?>
+                                        <?php
+                                        $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
+                                        $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                        ?>
+                                        <a class="btn btn-info btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-help1"></i></a>
+                                        <?php endif; ?>
+                                        <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
+                                        <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-look"></i></a>
+                                    </div>
                                 </div>
-                            </div>
                         </div>
                     </div>
                 </div>

--- a/app/views/layout/header.php
+++ b/app/views/layout/header.php
@@ -1,6 +1,8 @@
 <?php
 require_once __DIR__ . '/../../../bootstrap.php';
+require_once __DIR__ . '/../../models/Cart.php';
 header('Content-Type: text/html; charset=UTF-8');
+$cartCount = Cart::count();
 $menu = (function () {
     ob_start();
     include __DIR__ . '/menu.php';
@@ -87,6 +89,10 @@ echo "<!DOCTYPE html>\n";
                         <!-- Header Action Start -->
                         <div class="col-xl-2 col-6">
                             <div class="header-actions">
+                                <a href="<?= asset('cart.php') ?>" class="header-action-btn header-action-btn-cart">
+                                    <i class="pe-7s-shopbag"></i>
+                                    <span class="header-action-num"><?= htmlspecialchars((string)$cartCount, ENT_QUOTES, 'UTF-8') ?></span>
+                                </a>
 
                                 <!-- Mobile Menu Hambarger Action Button Start -->
                                 <a href="javascript:void(0)" class="header-action-btn header-action-btn-menu d-xl-none d-lg-block">

--- a/app/views/layout/menu.php
+++ b/app/views/layout/menu.php
@@ -7,6 +7,7 @@ $menuItems = [
 
 if (isset($_SESSION['username'])) {
     $menuItems[] = ['href' => 'prendas.php', 'label' => 'PRENDAS'];
+    $menuItems[] = ['href' => 'pedidos.php', 'label' => 'PEDIDOS'];
     $menuItems[] = ['href' => 'logout.php', 'label' => 'CERRAR SESION'];
 } else {
     $menuItems[] = ['href' => 'inicio.php', 'label' => 'INICIAR SESION'];

--- a/app/views/layout/menu.php
+++ b/app/views/layout/menu.php
@@ -5,10 +5,6 @@ $menuItems = [
     ['href' => 'usada.php', 'label' => '2DA MANO'],
 ];
 
-require_once __DIR__ . '/../../models/Cart.php';
-$cartCount = Cart::count();
-$menuItems[] = ['href' => 'cart.php', 'label' => $cartCount > 0 ? 'CARRITO (' . $cartCount . ')' : 'CARRITO'];
-
 if (isset($_SESSION['username'])) {
     $menuItems[] = ['href' => 'prendas.php', 'label' => 'PRENDAS'];
     $menuItems[] = ['href' => 'logout.php', 'label' => 'CERRAR SESION'];

--- a/app/views/layout/menu.php
+++ b/app/views/layout/menu.php
@@ -5,6 +5,10 @@ $menuItems = [
     ['href' => 'usada.php', 'label' => '2DA MANO'],
 ];
 
+require_once __DIR__ . '/../../models/Cart.php';
+$cartCount = Cart::count();
+$menuItems[] = ['href' => 'cart.php', 'label' => $cartCount > 0 ? 'CARRITO (' . $cartCount . ')' : 'CARRITO'];
+
 if (isset($_SESSION['username'])) {
     $menuItems[] = ['href' => 'prendas.php', 'label' => 'PRENDAS'];
     $menuItems[] = ['href' => 'logout.php', 'label' => 'CERRAR SESION'];

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -111,18 +111,27 @@
                                 <span class="price">
                                     <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
                                 </span>
+                                <?php
+                                $tag = strtolower($garment['tag_text'] ?? '');
+                                $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+                                $showAsk  = $tag !== 'vendido';
+                                ?>
                                 <div class="shop-list-btn">
+                                    <?php if ($showCart): ?>
                                     <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
                                         <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
+                                    <?php endif; ?>
+                                    <?php if ($showAsk): ?>
                                     <?php
                                     $waMessage = 'Por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
+                                    <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>
                                 </div>
@@ -303,19 +312,28 @@
 
 
                             <!-- Cart & Wishlist Button Start -->
+                            <?php
+                            $tag = strtolower($garment['tag_text'] ?? '');
+                            $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+                            $showAsk  = $tag !== 'vendido';
+                            ?>
                             <div class="cart-wishlist-btn pb-4 mb-n3">
                                 <div class="add-to_cart mb-3">
+                                    <?php if ($showCart): ?>
                                     <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                         <input type="hidden" name="action" value="add">
                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                       <input type="hidden" name="quantity" value="1">
                                       <button type="submit" class="btn btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
+                                    <?php endif; ?>
+                                    <?php if ($showAsk): ?>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a class="btn btn-info btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-help1"></i></a>
+                                    <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-look"></i></a>
                                   </div>

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -112,11 +112,17 @@
                                     <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
                                 </span>
                                 <div class="shop-list-btn">
+                                    <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                        <input type="hidden" name="action" value="add">
+                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                        <input type="hidden" name="quantity" value="1">
+                                        <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                    </form>
                                     <?php
                                     $waMessage = 'Por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>
                                 </div>
@@ -299,11 +305,17 @@
                             <!-- Cart & Wishlist Button Start -->
                             <div class="cart-wishlist-btn pb-4 mb-n3">
                                 <div class="add-to_cart mb-3">
+                                    <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                        <input type="hidden" name="action" value="add">
+                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                        <input type="hidden" name="quantity" value="1">
+                                        <button type="submit" class="btn btn-dark btn-hover-primary">Agregar al carrito</button>
+                                    </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-outline-dark btn-hover-primary" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <a class="btn btn-outline-dark btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
                                 </div>

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -116,15 +116,15 @@
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                        <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
                                     <?php
                                     $waMessage = 'Por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>
                                 </div>
                             </div>
                         </div>
@@ -307,20 +307,20 @@
                                 <div class="add-to_cart mb-3">
                                     <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                         <input type="hidden" name="action" value="add">
-                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
-                                        <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-dark btn-hover-primary">Agregar al carrito</button>
+                                      <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                      <input type="hidden" name="quantity" value="1">
+                                      <button type="submit" class="btn btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-outline-dark btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <a class="btn btn-info btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-help1"></i></a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
-                                </div>
-                            </div>
-                            <!-- Cart & Wishlist Button End -->
+                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-look"></i></a>
+                                  </div>
+                              </div>
+                              <!-- Cart & Wishlist Button End -->
 
 
 

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -78,7 +78,7 @@
                         <tr>
                           <th>Imagen</th>
                           <th>Nombre</th>
-                          <th>Código</th>
+                          <th>Código Único</th>
                           <th>Precio</th>
                         </tr>
                       </thead>
@@ -104,8 +104,13 @@
                         </tr>
                         <?php endforeach; ?>
                       </tbody>
+                      <tfoot>
+                        <tr>
+                          <td colspan="3" class="text-end"><strong>Total</strong></td>
+                          <td><strong>$<?= number_format($total, 2); ?></strong></td>
+                        </tr>
+                      </tfoot>
                     </table>
-                    <div class="text-end"><strong>Total: $<?= number_format($total, 2); ?></strong></div>
                   </div>
                 </div>
                 <div class="modal-footer">

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -2,6 +2,21 @@
 <div class="section section-margin">
   <div class="container">
     <h3>Pedidos</h3>
+    <form method="get" class="mb-3">
+      <div class="row g-2">
+        <div class="col-auto">
+          <select name="status" class="form-select">
+            <option value="" <?= $currentStatus === '' ? 'selected' : ''; ?>>Todos</option>
+            <option value="pending" <?= $currentStatus === 'pending' ? 'selected' : ''; ?>>Pendientes</option>
+            <option value="confirmed" <?= $currentStatus === 'confirmed' ? 'selected' : ''; ?>>Confirmados</option>
+            <option value="rejected" <?= $currentStatus === 'rejected' ? 'selected' : ''; ?>>Rechazados</option>
+          </select>
+        </div>
+        <div class="col-auto">
+          <button type="submit" class="btn btn-primary">Filtrar</button>
+        </div>
+      </div>
+    </form>
     <?php if (empty($orders)): ?>
       <p>No hay pedidos.</p>
     <?php else: ?>
@@ -12,6 +27,7 @@
             <th>Nombre</th>
             <th>Teléfono</th>
             <th>Método</th>
+            <th>Estado</th>
             <th>Acciones</th>
           </tr>
         </thead>
@@ -21,6 +37,17 @@
             <td><?= htmlspecialchars($order['buyer_name'], ENT_QUOTES, 'UTF-8'); ?></td>
             <td><?= htmlspecialchars($order['phone'], ENT_QUOTES, 'UTF-8'); ?></td>
             <td><?= htmlspecialchars($order['payment_method'], ENT_QUOTES, 'UTF-8'); ?></td>
+            <td>
+              <?php
+                $iconClass = 'pe-7s-clock text-warning';
+                if ($order['status'] === 'confirmed') {
+                    $iconClass = 'pe-7s-check text-success';
+                } elseif ($order['status'] === 'rejected') {
+                    $iconClass = 'pe-7s-close-circle text-danger';
+                }
+              ?>
+              <i class="<?= $iconClass; ?>"></i>
+            </td>
             <td>
               <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#order-<?= (int)$order['id']; ?>">Ver prendas</button>
               <?php if ($order['status'] === 'pending'): ?>

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -72,13 +72,41 @@
                   <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                  <ul class="list-group">
-                  <?php foreach ($order['items'] as $item): ?>
-                    <li class="list-group-item">
-                      <?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?> x<?= (int)$item['quantity']; ?>
-                    </li>
-                  <?php endforeach; ?>
-                  </ul>
+                  <div class="table-responsive">
+                    <table class="table table-bordered">
+                      <thead>
+                        <tr>
+                          <th>Imagen</th>
+                          <th>Nombre</th>
+                          <th>Código</th>
+                          <th>Precio</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <?php $total = 0; foreach ($order['items'] as $item): $total += $item['sale_value'] * $item['quantity']; ?>
+                        <tr>
+                          <td>
+                            <?php
+                              $basePath = __DIR__ . '/../../';
+                              $img = $item['image_primary'] ?? '';
+                              $imgSrc = '';
+                              if ($img && (filter_var($img, FILTER_VALIDATE_URL) || is_file($basePath . $img))) {
+                                $imgSrc = asset($img);
+                              }
+                            ?>
+                            <?php if ($imgSrc): ?>
+                              <img class="img-thumbnail" style="width: 60px;" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
+                            <?php endif; ?>
+                          </td>
+                          <td><?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?></td>
+                          <td><?= htmlspecialchars($item['unique_code'], ENT_QUOTES, 'UTF-8'); ?></td>
+                          <td>$<?= number_format((float)$item['sale_value'], 2); ?></td>
+                        </tr>
+                        <?php endforeach; ?>
+                      </tbody>
+                    </table>
+                    <div class="text-end"><strong>Total: $<?= number_format($total, 2); ?></strong></div>
+                  </div>
                 </div>
                 <div class="modal-footer">
                   <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -31,8 +31,8 @@
             <th>Acciones</th>
           </tr>
         </thead>
-        <tbody>
-        <?php foreach ($orders as $order): ?>
+          <tbody>
+          <?php $orderModals = []; foreach ($orders as $order): ?>
           <tr>
             <td><?= htmlspecialchars($order['buyer_name'], ENT_QUOTES, 'UTF-8'); ?></td>
             <td><?= htmlspecialchars($order['phone'], ENT_QUOTES, 'UTF-8'); ?></td>
@@ -63,67 +63,70 @@
               </form>
               <?php endif; ?>
             </td>
-          </tr>
-          <div class="modal fade" id="order-<?= (int)$order['id']; ?>" tabindex="-1" aria-hidden="true">
-            <div class="modal-dialog">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <h5 class="modal-title">Prendas del pedido #<?= (int)$order['id']; ?></h5>
-                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                </div>
-                <div class="modal-body">
-                  <div class="table-responsive">
-                    <table class="table table-bordered">
-                      <thead>
-                        <tr>
-                          <th>Imagen</th>
-                          <th>Nombre</th>
-                          <th>Código Único</th>
-                          <th>Precio</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <?php $total = 0; foreach ($order['items'] as $item): $total += $item['sale_value'] * $item['quantity']; ?>
-                        <tr>
-                          <td>
-                            <?php
-                              $basePath = __DIR__ . '/../../';
-                              $img = $item['image_primary'] ?? '';
-                              $imgSrc = '';
-                              if ($img && (filter_var($img, FILTER_VALIDATE_URL) || is_file($basePath . $img))) {
-                                $imgSrc = asset($img);
-                              }
-                            ?>
-                            <?php if ($imgSrc): ?>
-                              <img class="img-thumbnail" style="width: 60px;" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
-                            <?php endif; ?>
-                          </td>
-                          <td><?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?></td>
-                          <td><?= htmlspecialchars($item['unique_code'], ENT_QUOTES, 'UTF-8'); ?></td>
-                          <td>$<?= number_format((float)$item['sale_value'], 2); ?></td>
-                        </tr>
-                        <?php endforeach; ?>
-                      </tbody>
-                      <tfoot>
-                        <tr>
-                          <td colspan="3" class="text-end"><strong>Total</strong></td>
-                          <td><strong>$<?= number_format($total, 2); ?></strong></td>
-                        </tr>
-                      </tfoot>
-                    </table>
+            </tr>
+            <?php ob_start(); ?>
+            <div class="modal fade" id="order-<?= (int)$order['id']; ?>" tabindex="-1" aria-hidden="true">
+              <div class="modal-dialog">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title">Prendas del pedido #<?= (int)$order['id']; ?></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                   </div>
-                </div>
-                <div class="modal-footer">
-                  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                  <div class="modal-body">
+                    <div class="table-responsive">
+                      <table class="table table-bordered">
+                        <thead>
+                          <tr>
+                            <th>Imagen</th>
+                            <th>Nombre</th>
+                            <th>Código Único</th>
+                            <th>Precio</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <?php $total = 0; foreach ($order['items'] as $item): $total += $item['sale_value'] * $item['quantity']; ?>
+                          <tr>
+                            <td>
+                              <?php
+                                $basePath = __DIR__ . '/../../';
+                                $img = $item['image_primary'] ?? '';
+                                $imgSrc = '';
+                                if ($img && (filter_var($img, FILTER_VALIDATE_URL) || is_file($basePath . $img))) {
+                                  $imgSrc = asset($img);
+                                }
+                              ?>
+                              <?php if ($imgSrc): ?>
+                                <img class="img-thumbnail" style="width: 60px;" src="<?= htmlspecialchars($imgSrc, ENT_QUOTES, 'UTF-8'); ?>" alt="<?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?>">
+                              <?php endif; ?>
+                            </td>
+                            <td><?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?></td>
+                            <td><?= htmlspecialchars($item['unique_code'], ENT_QUOTES, 'UTF-8'); ?></td>
+                            <td>$<?= number_format((float)$item['sale_value'], 2); ?></td>
+                          </tr>
+                          <?php endforeach; ?>
+                        </tbody>
+                        <tfoot>
+                          <tr>
+                            <td colspan="3" class="text-end"><strong>Total</strong></td>
+                            <td><strong>$<?= number_format($total, 2); ?></strong></td>
+                          </tr>
+                        </tfoot>
+                      </table>
+                    </div>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        <?php endforeach; ?>
-        </tbody>
-      </table>
+            <?php $orderModals[] = ob_get_clean(); ?>
+          <?php endforeach; ?>
+          </tbody>
+        </table>
+        <?php foreach ($orderModals as $modal) echo $modal; ?>
+      </div>
+      <?php endif; ?>
     </div>
-    <?php endif; ?>
   </div>
-</div>
-<?php include __DIR__ . '/layout/footer.php'; ?>
+  <?php include __DIR__ . '/layout/footer.php'; ?>

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -1,0 +1,69 @@
+<?php include __DIR__ . '/layout/header.php'; ?>
+<div class="section section-margin">
+  <div class="container">
+    <h3>Pedidos</h3>
+    <?php if (empty($orders)): ?>
+      <p>No hay pedidos.</p>
+    <?php else: ?>
+    <div class="table-responsive">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>Teléfono</th>
+            <th>Método</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($orders as $order): ?>
+          <tr>
+            <td><?= htmlspecialchars($order['buyer_name'], ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?= htmlspecialchars($order['phone'], ENT_QUOTES, 'UTF-8'); ?></td>
+            <td><?= htmlspecialchars($order['payment_method'], ENT_QUOTES, 'UTF-8'); ?></td>
+            <td>
+              <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#order-<?= (int)$order['id']; ?>">Ver prendas</button>
+              <?php if ($order['status'] === 'pending'): ?>
+              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                <input type="hidden" name="action" value="confirm">
+                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
+                <button type="submit" class="btn btn-sm btn-success">Confirmar</button>
+              </form>
+              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                <input type="hidden" name="action" value="reject">
+                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
+                <button type="submit" class="btn btn-sm btn-danger">Rechazar</button>
+              </form>
+              <?php endif; ?>
+            </td>
+          </tr>
+          <div class="modal fade" id="order-<?= (int)$order['id']; ?>" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog">
+              <div class="modal-content">
+                <div class="modal-header">
+                  <h5 class="modal-title">Prendas del pedido #<?= (int)$order['id']; ?></h5>
+                  <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                  <ul class="list-group">
+                  <?php foreach ($order['items'] as $item): ?>
+                    <li class="list-group-item">
+                      <?= htmlspecialchars($item['name'], ENT_QUOTES, 'UTF-8'); ?> x<?= (int)$item['quantity']; ?>
+                    </li>
+                  <?php endforeach; ?>
+                  </ul>
+                </div>
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        <?php endforeach; ?>
+        </tbody>
+      </table>
+    </div>
+    <?php endif; ?>
+  </div>
+</div>
+<?php include __DIR__ . '/layout/footer.php'; ?>

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -27,14 +27,21 @@
         <?php
           $waMessage = 'Por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
           $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+          $tag = strtolower($garment['tag_text'] ?? '');
+          $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+          $showAsk  = $tag !== 'vendido';
         ?>
+        <?php if ($showAsk): ?>
         <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-info"><i class="pe-7s-help1"></i></a>
+        <?php endif; ?>
+        <?php if ($showCart): ?>
         <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="mt-3">
           <input type="hidden" name="action" value="add">
           <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
           <input type="hidden" name="quantity" value="1">
           <button type="submit" class="btn btn-success"><i class="pe-7s-shopbag"></i></button>
         </form>
+        <?php endif; ?>
       </div>
     </div>
   </div>

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -28,12 +28,12 @@
           $waMessage = 'Por favor enviar información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
           $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
         ?>
-        <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary">Preguntar</a>
+        <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-info"><i class="pe-7s-help1"></i></a>
         <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="mt-3">
           <input type="hidden" name="action" value="add">
           <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
           <input type="hidden" name="quantity" value="1">
-          <button type="submit" class="btn btn-success">Agregar al carrito</button>
+          <button type="submit" class="btn btn-success"><i class="pe-7s-shopbag"></i></button>
         </form>
       </div>
     </div>

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -29,6 +29,15 @@
           $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
         ?>
         <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-primary">Preguntar</a>
+        <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="mt-3">
+          <input type="hidden" name="action" value="add">
+          <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+          <div class="mb-2">
+            <label for="quantity" class="form-label">Cantidad</label>
+            <input type="number" name="quantity" id="quantity" value="1" min="1" class="form-control w-25">
+          </div>
+          <button type="submit" class="btn btn-success">Agregar al carrito</button>
+        </form>
       </div>
     </div>
   </div>

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -32,10 +32,7 @@
         <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="mt-3">
           <input type="hidden" name="action" value="add">
           <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
-          <div class="mb-2">
-            <label for="quantity" class="form-label">Cantidad</label>
-            <input type="number" name="quantity" id="quantity" value="1" min="1" class="form-control w-25">
-          </div>
+          <input type="hidden" name="quantity" value="1">
           <button type="submit" class="btn btn-success">Agregar al carrito</button>
         </form>
       </div>

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -112,18 +112,27 @@
                                 <span class="price">
                                     <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
                                 </span>
+                                <?php
+                                $tag = strtolower($garment['tag_text'] ?? '');
+                                $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+                                $showAsk  = $tag !== 'vendido';
+                                ?>
                                 <div class="shop-list-btn">
+                                    <?php if ($showCart): ?>
                                     <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
                                         <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
+                                    <?php endif; ?>
+                                    <?php if ($showAsk): ?>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
+                                    <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>
                                 </div>
@@ -304,19 +313,28 @@
 
 
                             <!-- Cart & Wishlist Button Start -->
+                            <?php
+                            $tag = strtolower($garment['tag_text'] ?? '');
+                            $showCart = $tag !== 'reservado' && $tag !== 'vendido';
+                            $showAsk  = $tag !== 'vendido';
+                            ?>
                             <div class="cart-wishlist-btn pb-4 mb-n3">
                                 <div class="add-to_cart mb-3">
+                                    <?php if ($showCart): ?>
                                     <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                         <input type="hidden" name="action" value="add">
                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                       <input type="hidden" name="quantity" value="1">
                                       <button type="submit" class="btn btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
+                                    <?php endif; ?>
+                                    <?php if ($showAsk): ?>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
                                     <a class="btn btn-info btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-help1"></i></a>
+                                    <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-look"></i></a>
                                   </div>

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -113,11 +113,17 @@
                                     <span class="new">$<?= number_format((float)$garment['sale_value'], 2); ?></span>
                                 </span>
                                 <div class="shop-list-btn">
+                                    <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                        <input type="hidden" name="action" value="add">
+                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                        <input type="hidden" name="quantity" value="1">
+                                        <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                    </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary">Preguntar</a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>
                                 </div>
@@ -300,11 +306,17 @@
                             <!-- Cart & Wishlist Button Start -->
                             <div class="cart-wishlist-btn pb-4 mb-n3">
                                 <div class="add-to_cart mb-3">
+                                    <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                                        <input type="hidden" name="action" value="add">
+                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                        <input type="hidden" name="quantity" value="1">
+                                        <button type="submit" class="btn btn-dark btn-hover-primary">Agregar al carrito</button>
+                                    </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-outline-dark btn-hover-primary" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <a class="btn btn-outline-dark btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
                                     <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
                                 </div>

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -117,15 +117,15 @@
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-sm btn-success btn-hover-primary">Agregar al carrito</button>
+                                        <button type="submit" class="btn btn-sm btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-dark btn-hover-primary ms-1">Preguntar</a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-info btn-hover-primary ms-1"><i class="pe-7s-help1"></i></a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-outline-secondary btn-hover-primary ms-1">Ver detalle</a>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1"><i class="pe-7s-look"></i></a>
                                 </div>
                             </div>
                         </div>
@@ -308,20 +308,20 @@
                                 <div class="add-to_cart mb-3">
                                     <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
                                         <input type="hidden" name="action" value="add">
-                                        <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
-                                        <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-dark btn-hover-primary">Agregar al carrito</button>
+                                      <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
+                                      <input type="hidden" name="quantity" value="1">
+                                      <button type="submit" class="btn btn-success btn-hover-primary"><i class="pe-7s-shopbag"></i></button>
                                     </form>
                                     <?php
                                     $waMessage = 'por favor enviar información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-outline-dark btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>">Preguntar</a>
+                                    <a class="btn btn-info btn-hover-primary ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-help1"></i></a>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-outline-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>">Ver detalle</a>
-                                </div>
-                            </div>
-                            <!-- Cart & Wishlist Button End -->
+                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>"><i class="pe-7s-look"></i></a>
+                                  </div>
+                              </div>
+                              <!-- Cart & Wishlist Button End -->
 
 
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -14,6 +14,9 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
+require_once __DIR__ . '/app/models/Cart.php';
+Cart::purgeExpired();
+
 function asset(string $path): string
 {
     return rtrim(BASE_URL, '/') . '/' . ltrim($path, '/');

--- a/cart.php
+++ b/cart.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/app/controllers/CartController.php';
+
+$controller = new CartController();
+$action = $_SERVER['REQUEST_METHOD'] === 'POST' ? ($_POST['action'] ?? 'index') : ($_GET['action'] ?? 'index');
+
+switch ($action) {
+    case 'add':
+        $controller->add();
+        break;
+    case 'remove':
+        $controller->remove();
+        break;
+    default:
+        $controller->index();
+        break;
+}

--- a/pedidos.php
+++ b/pedidos.php
@@ -1,19 +1,16 @@
 <?php
 require_once __DIR__ . '/bootstrap.php';
-require_once __DIR__ . '/app/controllers/CartController.php';
+require_once __DIR__ . '/app/controllers/PedidoController.php';
 
-$controller = new CartController();
+$controller = new PedidoController();
 $action = $_SERVER['REQUEST_METHOD'] === 'POST' ? ($_POST['action'] ?? 'index') : ($_GET['action'] ?? 'index');
 
 switch ($action) {
-    case 'add':
-        $controller->add();
+    case 'confirm':
+        $controller->confirm();
         break;
-    case 'remove':
-        $controller->remove();
-        break;
-    case 'checkout':
-        $controller->checkout();
+    case 'reject':
+        $controller->reject();
         break;
     default:
         $controller->index();


### PR DESCRIPTION
## Summary
- create Cart model, controller and view backed by database
- allow adding garments to a session-scoped cart and show item count in menu
- append cart_items table schema for persisting guest carts

## Testing
- `php -l app/models/Cart.php`
- `php -l app/controllers/CartController.php`
- `php -l cart.php`
- `php -l app/views/cart.php`
- `php -l app/views/prenda_detalle.php`
- `php -l app/views/layout/menu.php`


------
https://chatgpt.com/codex/tasks/task_b_68bb8fe415088326b70b3c2bfdad8cb1