### PR TITLE
Hide empty categories on new and used pages

### DIFF
--- a/app/controllers/NuevaController.php
+++ b/app/controllers/NuevaController.php
@@ -25,7 +25,10 @@ class NuevaController
         }
         $garments = array_slice($garments, ($page - 1) * $perPage, $perPage);
 
-        $categories = Category::all('nueva');
+        $categories = array_values(array_filter(
+            Category::all('nueva'),
+            static fn($cat) => (int)($cat['usage_count'] ?? 0) > 0
+        ));
         include __DIR__ . '/../views/nueva.php';
     }
 }

--- a/app/controllers/UsadaController.php
+++ b/app/controllers/UsadaController.php
@@ -25,7 +25,10 @@ class UsadaController
         }
         $garments = array_slice($garments, ($page - 1) * $perPage, $perPage);
 
-        $categories = Category::all('usada');
+        $categories = array_values(array_filter(
+            Category::all('usada'),
+            static fn($cat) => (int)($cat['usage_count'] ?? 0) > 0
+        ));
         include __DIR__ . '/../views/usada.php';
     }
 }


### PR DESCRIPTION
## Summary
- Filter new product categories to exclude empty ones
- Filter used product categories to exclude empty ones

## Testing
- `php -l app/controllers/NuevaController.php`
- `php -l app/controllers/UsadaController.php`


------
https://chatgpt.com/codex/tasks/task_b_68bcf692d670832695a2ced6b6e32900