### PR TITLE
Marcar prendas reservadas al crear pedido pendiente

### DIFF
--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -24,6 +24,11 @@ class Order
         $itemStmt->close();
         $mysqli->commit();
         $mysqli->close();
+
+        foreach ($items as $item) {
+            Garment::markReserved((int)$item['garment_id']);
+        }
+
         return $orderId;
     }
 


### PR DESCRIPTION
## Summary
- Asegura que al crear un pedido se marque cada prenda como "reservado".

## Testing
- `php -l app/models/Order.php`


------
https://chatgpt.com/codex/tasks/task_b_68bdbe7c296083268a5cc58334b95a51