### PR TITLE
Include garment image in WhatsApp message

### DIFF
--- a/app/views/home.php
+++ b/app/views/home.php
@@ -163,6 +163,10 @@
                                                   <?php
                                                   $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                                  $primaryImage = $garment['image_primary'] ?? '';
+                                                  if ($primaryImage) {
+                                                      $waLink .= '&media=' . urlencode(asset($primaryImage));
+                                                  }
                                                   ?>
                                                   <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                                   <?php endif; ?>
@@ -231,6 +235,10 @@
                                                   <?php
                                                   $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                                  $primaryImage = $garment['image_primary'] ?? '';
+                                                  if ($primaryImage) {
+                                                      $waLink .= '&media=' . urlencode(asset($primaryImage));
+                                                  }
                                                   ?>
                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                                   <?php endif; ?>
@@ -322,6 +330,10 @@
                                         <?php
                                         $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                         $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                        $primaryImage = $garment['image_primary'] ?? '';
+                                        if ($primaryImage) {
+                                            $waLink .= '&media=' . urlencode(asset($primaryImage));
+                                        }
                                         ?>
                                         <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                         <?php endif; ?>

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -129,6 +129,10 @@
                                     <?php
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                    $primaryImage = $garment['image_primary'] ?? '';
+                                    if ($primaryImage) {
+                                        $waLink .= '&media=' . urlencode(asset($primaryImage));
+                                    }
                                     ?>
                                     <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?> 
@@ -331,6 +335,10 @@
                                     <?php
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                    $primaryImage = $garment['image_primary'] ?? '';
+                                    if ($primaryImage) {
+                                        $waLink .= '&media=' . urlencode(asset($primaryImage));
+                                    }
                                     ?>
                                     <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?>

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -27,6 +27,10 @@
         <?php
           $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
           $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+          $primaryImage = $garment['image_primary'] ?? '';
+          if ($primaryImage) {
+              $waLink .= '&media=' . urlencode(asset($primaryImage));
+          }
           $tag = strtolower($garment['tag_text'] ?? '');
           $showCart = $tag !== 'reservado' && $tag !== 'vendido';
           $showAsk  = $tag !== 'vendido';

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -130,6 +130,10 @@
                                     <?php
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                    $primaryImage = $garment['image_primary'] ?? '';
+                                    if ($primaryImage) {
+                                        $waLink .= '&media=' . urlencode(asset($primaryImage));
+                                    }
                                     ?>
                                     <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?>
@@ -332,6 +336,10 @@
                                     <?php
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
+                                    $primaryImage = $garment['image_primary'] ?? '';
+                                    if ($primaryImage) {
+                                        $waLink .= '&media=' . urlencode(asset($primaryImage));
+                                    }
                                     ?>
                                     <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- Attach each garment's primary image URL to WhatsApp message links
- Apply image parameter across garment detail, home, new, and used views

## Testing
- `php -l app/views/prenda_detalle.php`
- `php -l app/views/home.php`
- `php -l app/views/nueva.php`
- `php -l app/views/usada.php`


------
https://chatgpt.com/codex/tasks/task_b_68be3421899c832697d91ca8552c5af5