### PR TITLE
Resaltar categoría seleccionada en rojo

### DIFF
--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -215,9 +215,9 @@
                             <h3 class="widget-title">Categorias</h3>
                             <div class="sidebar-body">
                                 <ul class="sidebar-list">
-                                    <li><a href="nueva.php<?= $sort || $perPage ? '?' . http_build_query(array_filter(['sort' => $sort, 'perPage' => $perPage])) : '' ?>"<?= $categoryId === null ? ' class="active"' : '' ?>>Todas</a></li>
+                                    <li><a href="nueva.php<?= $sort || $perPage ? '?' . http_build_query(array_filter(['sort' => $sort, 'perPage' => $perPage])) : '' ?>"<?= $categoryId === null ? ' class="active text-danger"' : '' ?>>Todas</a></li>
                                     <?php foreach ($categories as $cat): ?>
-                                        <li><a href="nueva.php?<?= http_build_query(array_filter(['category' => $cat['id'], 'sort' => $sort, 'perPage' => $perPage])) ?>"<?= $categoryId === (int)$cat['id'] ? ' class="active"' : '' ?>><?= htmlspecialchars($cat['name'], ENT_QUOTES, 'UTF-8'); ?> (<?= $cat['usage_count']; ?>)</a></li>
+                                        <li><a href="nueva.php?<?= http_build_query(array_filter(['category' => $cat['id'], 'sort' => $sort, 'perPage' => $perPage])) ?>"<?= $categoryId === (int)$cat['id'] ? ' class="active text-danger"' : '' ?>><?= htmlspecialchars($cat['name'], ENT_QUOTES, 'UTF-8'); ?> (<?= $cat['usage_count']; ?>)</a></li>
                                     <?php endforeach; ?>
                                 </ul>
                             </div>

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -216,9 +216,9 @@
                             <h3 class="widget-title">Categorias</h3>
                             <div class="sidebar-body">
                                 <ul class="sidebar-list">
-                                    <li><a href="usada.php<?= $sort || $perPage ? '?' . http_build_query(array_filter(['sort' => $sort, 'perPage' => $perPage])) : '' ?>"<?= $categoryId === null ? ' class="active"' : '' ?>>Todas</a></li>
+                                    <li><a href="usada.php<?= $sort || $perPage ? '?' . http_build_query(array_filter(['sort' => $sort, 'perPage' => $perPage])) : '' ?>"<?= $categoryId === null ? ' class="active text-danger"' : '' ?>>Todas</a></li>
                                     <?php foreach ($categories as $cat): ?>
-                                    <li><a href="usada.php?<?= http_build_query(array_filter(['category' => $cat['id'], 'sort' => $sort, 'perPage' => $perPage])) ?>"<?= $categoryId === (int)$cat['id'] ? ' class="active"' : '' ?>><?= htmlspecialchars($cat['name'], ENT_QUOTES, 'UTF-8'); ?> (<?= $cat['usage_count']; ?>)</a></li>
+                                    <li><a href="usada.php?<?= http_build_query(array_filter(['category' => $cat['id'], 'sort' => $sort, 'perPage' => $perPage])) ?>"<?= $categoryId === (int)$cat['id'] ? ' class="active text-danger"' : '' ?>><?= htmlspecialchars($cat['name'], ENT_QUOTES, 'UTF-8'); ?> (<?= $cat['usage_count']; ?>)</a></li>
                                     <?php endforeach; ?>
                                 </ul>
                             </div>


### PR DESCRIPTION
## Summary
- Muestra en rojo la categoría seleccionada en listas de productos nuevos y usados.

## Testing
- `php -l app/views/nueva.php`
- `php -l app/views/usada.php`


------
https://chatgpt.com/codex/tasks/task_b_68bf6f4836008326adad6d15e876aa54