### PR TITLE
Mostrar talla de la prenda junto al nombre

### DIFF
--- a/app/views/home.php
+++ b/app/views/home.php
@@ -139,7 +139,7 @@
                                             <div class="content">
                                                 <h5 class="title"><a href="#" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><?= htmlspecialchars($garment['name'], ENT_QUOTES, 'UTF-8'); ?></a></h5>                                                
                                                 <?php if (!empty($garment['size'])): ?>
-                                                <div class="mb-2"><small>Talla: <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></small></div>
+                                                <div class="mb-2"><span class="badge rounded-pill bg-danger">Talla <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></span></div>
                                                 <?php endif; ?>
                 <span class="ratings">
                                                     <span class="rating-wrap">
@@ -210,7 +210,7 @@
                                             <div class="content">
                                                 <h5 class="title"><a href="#" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><?= htmlspecialchars($garment['name'], ENT_QUOTES, 'UTF-8'); ?></a></h5>                                                
                                                 <?php if (!empty($garment['size'])): ?>
-                                                <div class="mb-2"><small>Talla: <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></small></div>
+                                                <div class="mb-2"><span class="badge rounded-pill bg-danger">Talla <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></span></div>
                                                 <?php endif; ?>
                                                 <span class="ratings">
                                                   <span class="rating-wrap">

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -89,7 +89,7 @@
                             <div class="content">
                                 <h5 class="title"><a href="#" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><?= htmlspecialchars($garment['name'], ENT_QUOTES, 'UTF-8'); ?></a></h5>
                                 <?php if (!empty($garment['size'])): ?>
-                                <div class="mb-2"><small>Talla: <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></small></div>
+                                <div class="mb-2"><span class="badge rounded-pill bg-danger">Talla <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></span></div>
                                 <?php endif; ?>
                                  <!-- SKU Start -->
                             <?php if (!empty($garment['unique_code'])): ?>

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -89,7 +89,7 @@
                             <div class="content">
                                 <h5 class="title"><a href="#" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><?= htmlspecialchars($garment['name'], ENT_QUOTES, 'UTF-8'); ?></a></h5>
                                 <?php if (!empty($garment['size'])): ?>
-                                <div class="mb-2"><small>Talla: <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></small></div>
+                                <div class="mb-2"><span class="badge rounded-pill bg-danger">Talla <?= htmlspecialchars($garment['size'], ENT_QUOTES, 'UTF-8'); ?></span></div>
                                 <?php endif; ?>
                                  <!-- SKU Start -->
                             <?php if (!empty($garment['unique_code'])): ?>


### PR DESCRIPTION
## Summary
- Muestra la talla de la prenda debajo del nombre del producto en listados de productos usados, nuevos y en la página de inicio

## Testing
- `php -l app/views/usada.php`
- `php -l app/views/nueva.php`
- `php -l app/views/home.php`


------
https://chatgpt.com/codex/tasks/task_b_68c4bee08248832685802eaa5fb7ad2d