### PR TITLE
Notificar venta nueva por WhatsApp

### DIFF
--- a/app/controllers/CartController.php
+++ b/app/controllers/CartController.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../models/Cart.php';
 require_once __DIR__ . '/../models/Order.php';
 require_once __DIR__ . '/../models/Garment.php';
+require_once __DIR__ . '/../services/WhatsAppNotifier.php';
 
 class CartController
 {
@@ -59,7 +60,8 @@ class CartController
         $payment = filter_input(INPUT_POST, 'payment', FILTER_SANITIZE_STRING);
         $items = Cart::items();
         if ($name !== '' && $phone !== '' && $payment && !empty($items)) {
-            Order::create($name, $phone, $payment, $items);
+            $orderId = Order::create($name, $phone, $payment, $items);
+            WhatsAppNotifier::sendNewOrderNotification($orderId);
             Cart::clear(false);
             foreach ($items as $item) {
                 Garment::markReserved((int)$item['garment_id']);

--- a/app/services/WhatsAppNotifier.php
+++ b/app/services/WhatsAppNotifier.php
@@ -1,0 +1,33 @@
+<?php
+class WhatsAppNotifier
+{
+    private const RECIPIENT = 'whatsapp:+593999591820';
+
+    public static function sendNewOrderNotification(int $orderId): void
+    {
+        $sid = getenv('TWILIO_SID');
+        $token = getenv('TWILIO_TOKEN');
+        $from = getenv('TWILIO_WHATSAPP_FROM');
+
+        if (!$sid || !$token || !$from) {
+            return;
+        }
+
+        $message = "Nueva venta realizada. Pedido #{$orderId}";
+        $url = "https://api.twilio.com/2010-04-01/Accounts/{$sid}/Messages.json";
+
+        $data = http_build_query([
+            'From' => $from,
+            'To'   => self::RECIPIENT,
+            'Body' => $message,
+        ]);
+
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+        curl_setopt($ch, CURLOPT_USERPWD, $sid . ':' . $token);
+        curl_exec($ch);
+        curl_close($ch);
+    }
+}


### PR DESCRIPTION
## Resumen
- Agrega servicio `WhatsAppNotifier` que utiliza Twilio para enviar mensajes a `+593999591820`.
- Envía una notificación por WhatsApp cuando se crea un pedido en el checkout.

## Pruebas
- `php -l app/services/WhatsAppNotifier.php`
- `php -l app/controllers/CartController.php`


------
https://chatgpt.com/codex/tasks/task_b_68c6f14b5a4c8326b7e4b9e4011c061e