### PR TITLE
Add paid and delivered order states

### DIFF
--- a/ahorro.sql
+++ b/ahorro.sql
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS orders (
   buyer_name VARCHAR(100) NOT NULL,
   phone VARCHAR(30) NOT NULL,
   payment_method VARCHAR(20) NOT NULL,
-  status ENUM('pending','confirmed','rejected') DEFAULT 'pending',
+  status ENUM('pending','confirmed','paid','delivered','rejected') DEFAULT 'pending',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -6,7 +6,7 @@ class PedidoController
     public function index(): void
     {
         $status = filter_input(INPUT_GET, 'status', FILTER_SANITIZE_STRING);
-        $statusFilter = in_array($status, ['pending', 'confirmed', 'rejected'], true) ? $status : null;
+        $statusFilter = in_array($status, ['pending', 'confirmed', 'paid', 'delivered', 'rejected'], true) ? $status : null;
         $orders = Order::all($statusFilter);
         foreach ($orders as $index => $order) {
             $orders[$index]['items'] = Order::items((int)$order['id']);
@@ -21,6 +21,28 @@ class PedidoController
         $id = (int)$idRaw;
         if ($id > 0) {
             Order::confirm($id);
+        }
+        header('Location: ' . asset('pedidos.php'), true, 302);
+        exit;
+    }
+
+    public function pay(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $id = (int)$idRaw;
+        if ($id > 0) {
+            Order::pay($id);
+        }
+        header('Location: ' . asset('pedidos.php'), true, 302);
+        exit;
+    }
+
+    public function deliver(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $id = (int)$idRaw;
+        if ($id > 0) {
+            Order::deliver($id);
         }
         header('Location: ' . asset('pedidos.php'), true, 302);
         exit;

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -31,7 +31,7 @@ class Order
     public static function all(?string $status = null): array
     {
         $mysqli = obtenerConexion();
-        if ($status && in_array($status, ['pending', 'confirmed', 'rejected'], true)) {
+        if ($status && in_array($status, ['pending', 'confirmed', 'paid', 'delivered', 'rejected'], true)) {
             $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status FROM orders WHERE status = ? ORDER BY id DESC');
             $stmt->bind_param('s', $status);
             $stmt->execute();
@@ -82,6 +82,26 @@ class Order
         }
         $mysqli = obtenerConexion();
         $upd = $mysqli->prepare("UPDATE orders SET status='rejected' WHERE id=?");
+        $upd->bind_param('i', $orderId);
+        $upd->execute();
+        $upd->close();
+        $mysqli->close();
+    }
+
+    public static function pay(int $orderId): void
+    {
+        $mysqli = obtenerConexion();
+        $upd = $mysqli->prepare("UPDATE orders SET status='paid' WHERE id=?");
+        $upd->bind_param('i', $orderId);
+        $upd->execute();
+        $upd->close();
+        $mysqli->close();
+    }
+
+    public static function deliver(int $orderId): void
+    {
+        $mysqli = obtenerConexion();
+        $upd = $mysqli->prepare("UPDATE orders SET status='delivered' WHERE id=?");
         $upd->bind_param('i', $orderId);
         $upd->execute();
         $upd->close();

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -9,6 +9,8 @@
             <option value="" <?= $currentStatus === '' ? 'selected' : ''; ?>>Todos</option>
             <option value="pending" <?= $currentStatus === 'pending' ? 'selected' : ''; ?>>Pendientes</option>
             <option value="confirmed" <?= $currentStatus === 'confirmed' ? 'selected' : ''; ?>>Confirmados</option>
+            <option value="paid" <?= $currentStatus === 'paid' ? 'selected' : ''; ?>>Pagados</option>
+            <option value="delivered" <?= $currentStatus === 'delivered' ? 'selected' : ''; ?>>Entregados</option>
             <option value="rejected" <?= $currentStatus === 'rejected' ? 'selected' : ''; ?>>Rechazados</option>
           </select>
         </div>
@@ -44,6 +46,12 @@
                 if ($order['status'] === 'confirmed') {
                     $iconClass = 'pe-7s-check text-success';
                     $orden= 'Pedido Confirmado';
+                } elseif ($order['status'] === 'paid') {
+                    $iconClass = 'pe-7s-cash text-primary';
+                    $orden= 'Pedido Pagado';
+                } elseif ($order['status'] === 'delivered') {
+                    $iconClass = 'pe-7s-gift text-info';
+                    $orden= 'Pedido Entregado';
                 } elseif ($order['status'] === 'rejected') {
                     $iconClass = 'pe-7s-close-circle text-danger';
                     $orden= 'Pedido Rechazado';
@@ -64,7 +72,20 @@
                 <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
                 <button type="submit" class="btn btn-sm btn-danger">Rechazar</button>
               </form>
-              <?php else: ?>
+              <?php elseif ($order['status'] === 'confirmed'): ?>
+              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                <input type="hidden" name="action" value="pay">
+                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
+                <button type="submit" class="btn btn-sm btn-primary">Pagado</button>
+              </form>
+              <?php elseif ($order['status'] === 'paid'): ?>
+              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                <input type="hidden" name="action" value="deliver">
+                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
+                <button type="submit" class="btn btn-sm btn-success">Entregado</button>
+              </form>
+              <?php endif; ?>
+              <?php if ($order['status'] === 'rejected' || (isset($_SESSION['role']) && (int)$_SESSION['role'] === 1)): ?>
               <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline" onsubmit="return confirm('¿Está seguro de eliminar este pedido?');">
                 <input type="hidden" name="action" value="delete">
                 <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">

--- a/pedidos.php
+++ b/pedidos.php
@@ -9,6 +9,12 @@ switch ($action) {
     case 'confirm':
         $controller->confirm();
         break;
+    case 'pay':
+        $controller->pay();
+        break;
+    case 'deliver':
+        $controller->deliver();
+        break;
     case 'reject':
         $controller->reject();
         break;


### PR DESCRIPTION
## Summary
- add paid and delivered states to orders
- show next-step actions and admin delete rules in pedidos view
- support new states in controllers, routing, and SQL schema

## Testing
- `php -l pedidos.php`
- `php -l app/controllers/PedidoController.php`
- `php -l app/models/Order.php`
- `php -l app/views/pedidos.php`


------
https://chatgpt.com/codex/tasks/task_b_68c714b7684c8326bb28c0431ac47aff