### PR TITLE
Restringir acceso a páginas administrativas sin sesión

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -21,3 +21,11 @@ function asset(string $path): string
 {
     return rtrim(BASE_URL, '/') . '/' . ltrim($path, '/');
 }
+
+function require_login(): void
+{
+    if (!isset($_SESSION['username'])) {
+        header('Location: ' . asset('index.php'));
+        exit;
+    }
+}

--- a/cuentas.php
+++ b/cuentas.php
@@ -2,5 +2,7 @@
 require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/CuentaController.php';
 
+require_login();
+
 $controller = new CuentaController();
 $controller->index();

--- a/pedidos.php
+++ b/pedidos.php
@@ -2,6 +2,8 @@
 require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/PedidoController.php';
 
+require_login();
+
 $controller = new PedidoController();
 $action = $_SERVER['REQUEST_METHOD'] === 'POST' ? ($_POST['action'] ?? 'index') : ($_GET['action'] ?? 'index');
 

--- a/prendas.php
+++ b/prendas.php
@@ -2,5 +2,7 @@
 require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/PrendaController.php';
 
+require_login();
+
 $controller = new PrendaController();
 $controller->handle();

--- a/usuarios.php
+++ b/usuarios.php
@@ -2,5 +2,7 @@
 require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/app/controllers/UserController.php';
 
+require_login();
+
 $controller = new UserController();
 $controller->index();


### PR DESCRIPTION
## Resumen
- agregar un helper `require_login` en `bootstrap.php` para redirigir a `index.php` cuando la sesión no esté iniciada
- aplicar la validación en pedidos.php, prendas.php, usuarios.php y cuentas.php para impedir el acceso anónimo

## Pruebas
- php -l bootstrap.php
- php -l pedidos.php
- php -l prendas.php
- php -l usuarios.php
- php -l cuentas.php

------
https://chatgpt.com/codex/tasks/task_b_68ca135af8b88326911497497e110bac