### PR TITLE
Add delivered toggle to pedidos module

### DIFF
--- a/ahorro.sql
+++ b/ahorro.sql
@@ -134,8 +134,7 @@ CREATE TABLE IF NOT EXISTS orders (
   phone VARCHAR(30) NOT NULL,
   payment_method VARCHAR(20) NOT NULL,
   credit_id INT DEFAULT NULL,
-  entregado TINYINT(1) NOT NULL DEFAULT 0,
-  status ENUM('pending','confirmed','credit','paid','delivered','rejected') DEFAULT 'pending',
+  status ENUM('pending','confirmed','credit','paid','rejected') DEFAULT 'pending',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (credit_id) REFERENCES credits(id) ON DELETE SET NULL
 );

--- a/ahorro.sql
+++ b/ahorro.sql
@@ -134,6 +134,7 @@ CREATE TABLE IF NOT EXISTS orders (
   phone VARCHAR(30) NOT NULL,
   payment_method VARCHAR(20) NOT NULL,
   credit_id INT DEFAULT NULL,
+  entregado TINYINT(1) NOT NULL DEFAULT 0,
   status ENUM('pending','confirmed','credit','paid','delivered','rejected') DEFAULT 'pending',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (credit_id) REFERENCES credits(id) ON DELETE SET NULL

--- a/ahorro.sql
+++ b/ahorro.sql
@@ -134,6 +134,7 @@ CREATE TABLE IF NOT EXISTS orders (
   phone VARCHAR(30) NOT NULL,
   payment_method VARCHAR(20) NOT NULL,
   credit_id INT DEFAULT NULL,
+  entregado TINYINT(1) NOT NULL DEFAULT 0,
   status ENUM('pending','confirmed','credit','paid','rejected') DEFAULT 'pending',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (credit_id) REFERENCES credits(id) ON DELETE SET NULL

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -168,4 +168,20 @@ class PedidoController
         header('Location: ' . asset('pedidos.php'), true, 302);
         exit;
     }
+
+    public function toggleDelivered(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $deliveredRaw = filter_input(INPUT_POST, 'entregado', FILTER_SANITIZE_NUMBER_INT);
+
+        $id = (int)$idRaw;
+        $deliveredValue = $deliveredRaw !== null ? (int)$deliveredRaw : null;
+
+        if ($id > 0 && ($deliveredValue === 0 || $deliveredValue === 1)) {
+            Order::setDelivered($id, $deliveredValue === 1);
+        }
+
+        header('Location: ' . asset('pedidos.php'), true, 302);
+        exit;
+    }
 }

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -134,10 +134,6 @@ class PedidoController
                     $amount = round($amount, 2);
                     if ($amount > 0) {
                         CreditContribution::create((int)$order['credit_id'], $orderId, $amount, $date);
-                        $contributed = CreditContribution::sumByOrder($orderId);
-                        if ($contributed + 0.009 >= $total) {
-                            Order::pay($orderId);
-                        }
                     }
                 }
             }

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -8,7 +8,7 @@ class PedidoController
     public function index(): void
     {
         $status = filter_input(INPUT_GET, 'status', FILTER_SANITIZE_STRING);
-        $statusFilter = in_array($status, ['pending', 'confirmed', 'credit', 'paid', 'delivered', 'rejected'], true) ? $status : null;
+        $statusFilter = in_array($status, ['pending', 'confirmed', 'credit', 'paid', 'rejected'], true) ? $status : null;
         $orders = Order::all($statusFilter);
         $ordersTotal = 0;
         foreach ($orders as $index => $order) {
@@ -141,41 +141,6 @@ class PedidoController
                     }
                 }
             }
-        }
-
-        header('Location: ' . asset('pedidos.php'), true, 302);
-        exit;
-    }
-
-    public function deliver(): void
-    {
-        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
-        $id = (int)$idRaw;
-        if ($id > 0) {
-            Order::deliver($id);
-        }
-        header('Location: ' . asset('pedidos.php'), true, 302);
-        exit;
-    }
-
-    public function toggleDelivered(): void
-    {
-        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
-        $deliveredRaw = filter_input(
-            INPUT_POST,
-            'entregado',
-            FILTER_VALIDATE_INT,
-            ['options' => ['min_range' => 0, 'max_range' => 1]]
-        );
-
-        $id = (int)$idRaw;
-        $delivered = null;
-        if ($deliveredRaw !== null && $deliveredRaw !== false) {
-            $delivered = (int)$deliveredRaw === 1;
-        }
-
-        if ($id > 0 && $delivered !== null) {
-            Order::setDelivered($id, $delivered);
         }
 
         header('Location: ' . asset('pedidos.php'), true, 302);

--- a/app/controllers/PedidoController.php
+++ b/app/controllers/PedidoController.php
@@ -158,6 +158,30 @@ class PedidoController
         exit;
     }
 
+    public function toggleDelivered(): void
+    {
+        $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);
+        $deliveredRaw = filter_input(
+            INPUT_POST,
+            'entregado',
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 0, 'max_range' => 1]]
+        );
+
+        $id = (int)$idRaw;
+        $delivered = null;
+        if ($deliveredRaw !== null && $deliveredRaw !== false) {
+            $delivered = (int)$deliveredRaw === 1;
+        }
+
+        if ($id > 0 && $delivered !== null) {
+            Order::setDelivered($id, $delivered);
+        }
+
+        header('Location: ' . asset('pedidos.php'), true, 302);
+        exit;
+    }
+
     public function reject(): void
     {
         $idRaw = filter_input(INPUT_POST, 'id', FILTER_SANITIZE_NUMBER_INT);

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -31,7 +31,7 @@ class Order
     public static function all(?string $status = null): array
     {
         $mysqli = obtenerConexion();
-        $baseSql = 'SELECT o.id, o.buyer_name, o.phone, o.payment_method, o.status, o.credit_id, c.name AS credit_name, c.value AS credit_value '
+        $baseSql = 'SELECT o.id, o.buyer_name, o.phone, o.payment_method, o.status, o.credit_id, o.entregado, c.name AS credit_name, c.value AS credit_value '
                  . 'FROM orders o '
                  . 'LEFT JOIN credits c ON o.credit_id = c.id';
 
@@ -95,7 +95,7 @@ class Order
     public static function find(int $orderId): ?array
     {
         $mysqli = obtenerConexion();
-        $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status, credit_id FROM orders WHERE id = ?');
+        $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status, credit_id, entregado FROM orders WHERE id = ?');
         $stmt->bind_param('i', $orderId);
         $stmt->execute();
         $result = $stmt->get_result();
@@ -103,6 +103,17 @@ class Order
         $stmt->close();
         $mysqli->close();
         return $order;
+    }
+
+    public static function setDelivered(int $orderId, bool $delivered): void
+    {
+        $mysqli = obtenerConexion();
+        $value = $delivered ? 1 : 0;
+        $stmt = $mysqli->prepare('UPDATE orders SET entregado = ? WHERE id = ?');
+        $stmt->bind_param('ii', $value, $orderId);
+        $stmt->execute();
+        $stmt->close();
+        $mysqli->close();
     }
 
     public static function pay(int $orderId): void

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -132,10 +132,6 @@ class Order
 
     public static function credit(int $orderId, int $creditId): void
     {
-        $items = self::items($orderId);
-        foreach ($items as $item) {
-            Garment::setSaleDate((int)$item['garment_id']);
-        }
         $mysqli = obtenerConexion();
         $upd = $mysqli->prepare("UPDATE orders SET status='credit', credit_id=? WHERE id=?");
         $upd->bind_param('ii', $creditId, $orderId);

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -31,11 +31,11 @@ class Order
     public static function all(?string $status = null): array
     {
         $mysqli = obtenerConexion();
-        $baseSql = 'SELECT o.id, o.buyer_name, o.phone, o.payment_method, o.status, o.entregado, o.credit_id, c.name AS credit_name, c.value AS credit_value '
+        $baseSql = 'SELECT o.id, o.buyer_name, o.phone, o.payment_method, o.status, o.credit_id, c.name AS credit_name, c.value AS credit_value '
                  . 'FROM orders o '
                  . 'LEFT JOIN credits c ON o.credit_id = c.id';
 
-        if ($status && in_array($status, ['pending', 'confirmed', 'credit', 'paid', 'delivered', 'rejected'], true)) {
+        if ($status && in_array($status, ['pending', 'confirmed', 'credit', 'paid', 'rejected'], true)) {
             $stmt = $mysqli->prepare($baseSql . ' WHERE o.status = ? ORDER BY o.id DESC');
             $stmt->bind_param('s', $status);
             $stmt->execute();
@@ -95,7 +95,7 @@ class Order
     public static function find(int $orderId): ?array
     {
         $mysqli = obtenerConexion();
-        $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status, entregado, credit_id FROM orders WHERE id = ?');
+        $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status, credit_id FROM orders WHERE id = ?');
         $stmt->bind_param('i', $orderId);
         $stmt->execute();
         $result = $stmt->get_result();
@@ -141,28 +141,6 @@ class Order
             $total += (float)$item['sale_value'] * (int)$item['quantity'];
         }
         return $total;
-    }
-
-    public static function deliver(int $orderId): void
-    {
-        $mysqli = obtenerConexion();
-        $delivered = 1;
-        $upd = $mysqli->prepare("UPDATE orders SET status='delivered', entregado=? WHERE id=?");
-        $upd->bind_param('ii', $delivered, $orderId);
-        $upd->execute();
-        $upd->close();
-        $mysqli->close();
-    }
-
-    public static function setDelivered(int $orderId, bool $delivered): void
-    {
-        $mysqli = obtenerConexion();
-        $value = $delivered ? 1 : 0;
-        $stmt = $mysqli->prepare('UPDATE orders SET entregado = ? WHERE id = ?');
-        $stmt->bind_param('ii', $value, $orderId);
-        $stmt->execute();
-        $stmt->close();
-        $mysqli->close();
     }
 
     public static function delete(int $orderId): void

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -31,7 +31,7 @@ class Order
     public static function all(?string $status = null): array
     {
         $mysqli = obtenerConexion();
-        $baseSql = 'SELECT o.id, o.buyer_name, o.phone, o.payment_method, o.status, o.credit_id, c.name AS credit_name, c.value AS credit_value '
+        $baseSql = 'SELECT o.id, o.buyer_name, o.phone, o.payment_method, o.status, o.entregado, o.credit_id, c.name AS credit_name, c.value AS credit_value '
                  . 'FROM orders o '
                  . 'LEFT JOIN credits c ON o.credit_id = c.id';
 
@@ -95,7 +95,7 @@ class Order
     public static function find(int $orderId): ?array
     {
         $mysqli = obtenerConexion();
-        $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status, credit_id FROM orders WHERE id = ?');
+        $stmt = $mysqli->prepare('SELECT id, buyer_name, phone, payment_method, status, entregado, credit_id FROM orders WHERE id = ?');
         $stmt->bind_param('i', $orderId);
         $stmt->execute();
         $result = $stmt->get_result();
@@ -146,10 +146,22 @@ class Order
     public static function deliver(int $orderId): void
     {
         $mysqli = obtenerConexion();
-        $upd = $mysqli->prepare("UPDATE orders SET status='delivered' WHERE id=?");
-        $upd->bind_param('i', $orderId);
+        $delivered = 1;
+        $upd = $mysqli->prepare("UPDATE orders SET status='delivered', entregado=? WHERE id=?");
+        $upd->bind_param('ii', $delivered, $orderId);
         $upd->execute();
         $upd->close();
+        $mysqli->close();
+    }
+
+    public static function setDelivered(int $orderId, bool $delivered): void
+    {
+        $mysqli = obtenerConexion();
+        $value = $delivered ? 1 : 0;
+        $stmt = $mysqli->prepare('UPDATE orders SET entregado = ? WHERE id = ?');
+        $stmt->bind_param('ii', $value, $orderId);
+        $stmt->execute();
+        $stmt->close();
         $mysqli->close();
     }
 

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -301,7 +301,16 @@
                         <div class="form-text">Si no selecciona una fecha se usará la actual.</div>
                       </div>
                       <?php else: ?>
-                      <p class="text-success mb-0">Este pedido no tiene saldo pendiente.</p>
+                      <div class="d-flex align-items-center gap-2 flex-wrap">
+                        <p class="text-success mb-0">Este pedido no tiene saldo pendiente.</p>
+                        <?php if ($order['status'] === 'credit'): ?>
+                        <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="mb-0">
+                          <input type="hidden" name="action" value="pay">
+                          <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
+                          <button type="submit" class="btn btn-sm btn-primary">Pagado</button>
+                        </form>
+                        <?php endif; ?>
+                      </div>
                       <?php endif; ?>
                     </div>
                     <div class="modal-footer">

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -35,6 +35,7 @@
             <th>Teléfono</th>
             <th>Método</th>
             <th>Estado</th>
+            <th>Entregado</th>
             <th>Valor Total</th>
             <th>Acciones</th>
           </tr>
@@ -87,6 +88,17 @@
                 </div>
                 <?php endif; ?>
               <?php endif; ?>
+            </td>
+            <td class="text-center">
+              <?php $entregado = !empty($order['entregado']); ?>
+              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
+                <input type="hidden" name="action" value="toggle_delivered">
+                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
+                <input type="hidden" name="entregado" value="<?= $entregado ? 0 : 1; ?>">
+                <button type="submit" class="btn btn-sm <?= $entregado ? 'btn-success' : 'btn-danger'; ?>">
+                  <?= $entregado ? 'SI' : 'NO'; ?>
+                </button>
+              </form>
             </td>
             <td>$<?= number_format((float)$order['total'], 2); ?></td>
             <td>

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -11,7 +11,6 @@
             <option value="confirmed" <?= $currentStatus === 'confirmed' ? 'selected' : ''; ?>>Por Pagar</option>
             <option value="credit" <?= $currentStatus === 'credit' ? 'selected' : ''; ?>>Crédito</option>
             <option value="paid" <?= $currentStatus === 'paid' ? 'selected' : ''; ?>>Por Entregar</option>
-            <option value="delivered" <?= $currentStatus === 'delivered' ? 'selected' : ''; ?>>Entregados</option>
             <option value="rejected" <?= $currentStatus === 'rejected' ? 'selected' : ''; ?>>Rechazados</option>
           </select>
         </div>
@@ -35,7 +34,6 @@
             <th>Teléfono</th>
             <th>Método</th>
             <th>Estado</th>
-            <th>Entregado</th>
             <th>Valor Total</th>
             <th>Acciones</th>
           </tr>
@@ -59,9 +57,6 @@
                 } elseif ($order['status'] === 'paid') {
                     $iconClass = 'pe-7s-cash text-primary';
                     $orden= 'Pedido Pagado';
-                } elseif ($order['status'] === 'delivered') {
-                    $iconClass = 'pe-7s-gift text-info';
-                    $orden= 'Pedido Entregado';
                 } elseif ($order['status'] === 'rejected') {
                     $iconClass = 'pe-7s-close-circle text-danger';
                     $orden= 'Pedido Rechazado';
@@ -88,17 +83,6 @@
                 </div>
                 <?php endif; ?>
               <?php endif; ?>
-            </td>
-            <td class="text-center">
-              <?php $entregado = !empty($order['entregado']); ?>
-              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
-                <input type="hidden" name="action" value="toggle_delivered">
-                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
-                <input type="hidden" name="entregado" value="<?= $entregado ? 0 : 1; ?>">
-                <button type="submit" class="btn btn-sm <?= $entregado ? 'btn-success' : 'btn-danger'; ?>">
-                  <?= $entregado ? 'SI' : 'NO'; ?>
-                </button>
-              </form>
             </td>
             <td>$<?= number_format((float)$order['total'], 2); ?></td>
             <td>
@@ -127,11 +111,6 @@
               <?php if (!empty($order['credit_id'])): ?>
               <button type="button" class="btn btn-sm btn-outline-primary me-1" data-bs-toggle="modal" data-bs-target="#credit-contributions-<?= (int)$order['id']; ?>">Ver abonos</button>
               <?php endif; ?>
-              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline">
-                <input type="hidden" name="action" value="deliver">
-                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
-                <button type="submit" class="btn btn-sm btn-success">Entregado</button>
-              </form>
               <?php endif; ?>
               <?php if ($order['status'] === 'rejected' || (isset($_SESSION['role']) && (int)$_SESSION['role'] === 1)): ?>
               <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>" class="d-inline" onsubmit="return confirm('¿Está seguro de eliminar este pedido?');">

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -35,6 +35,7 @@
             <th>Método</th>
             <th>Estado</th>
             <th>Valor Total</th>
+            <th>Entregado</th>
             <th>Acciones</th>
           </tr>
         </thead>
@@ -85,6 +86,17 @@
               <?php endif; ?>
             </td>
             <td>$<?= number_format((float)$order['total'], 2); ?></td>
+            <td class="text-center">
+              <form method="post" action="<?= htmlspecialchars(asset('pedidos.php'), ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="action" value="toggle_entregado">
+                <input type="hidden" name="id" value="<?= (int)$order['id']; ?>">
+                <input type="hidden" name="entregado" value="<?= (int)($order['entregado'] ? 0 : 1); ?>">
+                <?php $entregadoActivo = !empty($order['entregado']); ?>
+                <button type="submit" class="btn btn-sm <?= $entregadoActivo ? 'btn-success' : 'btn-danger'; ?>">
+                  <?= $entregadoActivo ? 'SI' : 'NO'; ?>
+                </button>
+              </form>
+            </td>
             <td>
               <button class="btn btn-sm btn-info" data-bs-toggle="modal" data-bs-target="#order-<?= (int)$order['id']; ?>">Ver prendas</button>
               <?php if ($order['status'] === 'pending'): ?>

--- a/pedidos.php
+++ b/pedidos.php
@@ -20,12 +20,6 @@ switch ($action) {
     case 'contribute':
         $controller->contribute();
         break;
-    case 'deliver':
-        $controller->deliver();
-        break;
-    case 'toggle_delivered':
-        $controller->toggleDelivered();
-        break;
     case 'reject':
         $controller->reject();
         break;

--- a/pedidos.php
+++ b/pedidos.php
@@ -23,6 +23,9 @@ switch ($action) {
     case 'deliver':
         $controller->deliver();
         break;
+    case 'toggle_delivered':
+        $controller->toggleDelivered();
+        break;
     case 'reject':
         $controller->reject();
         break;

--- a/pedidos.php
+++ b/pedidos.php
@@ -26,6 +26,9 @@ switch ($action) {
     case 'delete':
         $controller->delete();
         break;
+    case 'toggle_entregado':
+        $controller->toggleDelivered();
+        break;
     default:
         $controller->index();
         break;


### PR DESCRIPTION
## Summary
- add the `entregado` column to the orders schema and expose it in the Order model
- show a delivered toggle in the pedidos view that switches between NO (red) and SI (green)
- allow toggling the delivered flag through a new controller action while keeping the deliver action in sync

## Testing
- php -l pedidos.php
- php -l app/controllers/PedidoController.php
- php -l app/models/Order.php
- php -l app/views/pedidos.php

------
https://chatgpt.com/codex/tasks/task_b_68ca1c9a4c9c8326ae81af7825c1ccf2