### PR TITLE
Replace icon library with Font Awesome

### DIFF
--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -48,7 +48,7 @@
                         <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
                           <input type="hidden" name="action" value="remove">
                           <input type="hidden" name="id" value="<?= (int)$item['id']; ?>">
-                          <button type="submit" class="btn btn-link p-0"><i class="pe-7s-trash"></i></button>
+                          <button type="submit" class="btn btn-link p-0"><i class="fa-solid fa-trash"></i></button>
                         </form>
                       </td>
                     </tr>

--- a/app/views/cart.php
+++ b/app/views/cart.php
@@ -48,7 +48,7 @@
                         <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>">
                           <input type="hidden" name="action" value="remove">
                           <input type="hidden" name="id" value="<?= (int)$item['id']; ?>">
-                          <button type="submit" class="btn btn-link p-0"><i class="fa-solid fa-trash"></i></button>
+                          <button type="submit" class="btn btn-link p-0"><i class="fa fa-trash"></i></button>
                         </form>
                       </td>
                     </tr>

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -29,8 +29,8 @@
                   <?php endforeach; ?>
             </div>
             <div class="swiper-pagination d-md-none"></div>
-            <div class="home-slider-prev swiper-button-prev main-slider-nav d-md-flex d-none"><i class="pe-7s-angle-left"></i></div>
-            <div class="home-slider-next swiper-button-next main-slider-nav d-md-flex d-none"><i class="pe-7s-angle-right"></i></div>
+            <div class="home-slider-prev swiper-button-prev main-slider-nav d-md-flex d-none"><i class="fa-solid fa-chevron-left"></i></div>
+            <div class="home-slider-next swiper-button-next main-slider-nav d-md-flex d-none"><i class="fa-solid fa-chevron-right"></i></div>
         </div>
     </div>
 </div>
@@ -133,7 +133,7 @@
                                                 </span>
                                                 <?php endif; ?>
                                                 <div class="actions">
-                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="pe-7s-search"></i></a>
+                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
                                                 </div>
                                             </div>
                                             <div class="content">
@@ -161,7 +161,7 @@
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
-                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
                                                   </form>
                                                   <?php endif; ?>
                                                   <?php if ($showAsk): ?>
@@ -169,18 +169,18 @@
                                                   $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
-                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
                                                   <?php endif; ?>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="pe-7s-look"></i></a>                                            </div>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>                                            </div>
                                           </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
                                 </div>
                                 <div class="swiper-pagination d-md-none"></div>
-                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="pe-7s-angle-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="pe-7s-angle-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-left"></i></div>
                             </div>
                         </div>
                     </div>
@@ -204,7 +204,7 @@
                                                 </span>
                                                 <?php endif; ?>
                                                 <div class="actions">
-                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="pe-7s-search"></i></a>
+                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
                                                 </div>
                                             </div>
                                             <div class="content">
@@ -232,7 +232,7 @@
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
-                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
                                                   </form>
                                                   <?php endif; ?>
                                                   <?php if ($showAsk): ?>
@@ -240,18 +240,18 @@
                                                   $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
-                                                 <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+                                                 <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
                                                   <?php endif; ?>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="pe-7s-look"></i></a>                                            </div>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>                                            </div>
                                         </div>
                                       </div>
                                     </div>
                                     <?php endforeach; ?>
                                 </div>
                                 <div class="swiper-pagination d-md-none"></div>
-                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="pe-7s-angle-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="pe-7s-angle-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-left"></i></div>
                             </div>
                         </div>
                     </div>
@@ -282,8 +282,8 @@
                                     </a>
                                     <?php endif; ?>
                                 </div>
-                                <div class="swiper-product-button-next swiper-button-next"><i class="pe-7s-angle-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev"><i class="pe-7s-angle-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next"><i class="fa-solid fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa-solid fa-chevron-left"></i></div>
                             </div>
                         </div>
                     </div>
@@ -322,7 +322,7 @@
                                             <input type="hidden" name="action" value="add">
                                             <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                             <input type="hidden" name="quantity" value="1">
-                                            <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+                                            <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
                                         </form>
                                         <?php endif; ?>
                                         <?php if ($showAsk): ?>
@@ -330,10 +330,10 @@
                                         $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                         $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                         ?>
-                                        <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+                                        <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
                                         <?php endif; ?>
                                         <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                        <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="pe-7s-look"></i></a>
+                                        <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
                                     </div>
                                 </div>
                         </div>

--- a/app/views/home.php
+++ b/app/views/home.php
@@ -29,8 +29,8 @@
                   <?php endforeach; ?>
             </div>
             <div class="swiper-pagination d-md-none"></div>
-            <div class="home-slider-prev swiper-button-prev main-slider-nav d-md-flex d-none"><i class="fa-solid fa-chevron-left"></i></div>
-            <div class="home-slider-next swiper-button-next main-slider-nav d-md-flex d-none"><i class="fa-solid fa-chevron-right"></i></div>
+            <div class="home-slider-prev swiper-button-prev main-slider-nav d-md-flex d-none"><i class="fa fa-chevron-left"></i></div>
+            <div class="home-slider-next swiper-button-next main-slider-nav d-md-flex d-none"><i class="fa fa-chevron-right"></i></div>
         </div>
     </div>
 </div>
@@ -133,7 +133,7 @@
                                                 </span>
                                                 <?php endif; ?>
                                                 <div class="actions">
-                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
+                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa fa-search"></i></a>
                                                 </div>
                                             </div>
                                             <div class="content">
@@ -161,7 +161,7 @@
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
-                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
                                                   </form>
                                                   <?php endif; ?>
                                                   <?php if ($showAsk): ?>
@@ -169,18 +169,18 @@
                                                   $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
-                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+                                                  <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                                   <?php endif; ?>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>                                            </div>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa fa-eye"></i></a>                                            </div>
                                           </div>
                                         </div>
                                     </div>
                                     <?php endforeach; ?>
                                 </div>
                                 <div class="swiper-pagination d-md-none"></div>
-                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="fa fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="fa fa-chevron-left"></i></div>
                             </div>
                         </div>
                     </div>
@@ -204,7 +204,7 @@
                                                 </span>
                                                 <?php endif; ?>
                                                 <div class="actions">
-                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
+                                                    <a href="#" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa fa-search"></i></a>
                                                 </div>
                                             </div>
                                             <div class="content">
@@ -232,7 +232,7 @@
                                                       <input type="hidden" name="action" value="add">
                                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                                       <input type="hidden" name="quantity" value="1">
-                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+                                                      <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
                                                   </form>
                                                   <?php endif; ?>
                                                   <?php if ($showAsk): ?>
@@ -240,18 +240,18 @@
                                                   $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                                   $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                                   ?>
-                                                 <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+                                                 <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                                   <?php endif; ?>
                                                   <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>                                            </div>
+                                                  <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa fa-eye"></i></a>                                            </div>
                                         </div>
                                       </div>
                                     </div>
                                     <?php endforeach; ?>
                                 </div>
                                 <div class="swiper-pagination d-md-none"></div>
-                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="fa-solid fa-chevron-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next swiper-button-white d-md-flex d-none"><i class="fa fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev swiper-button-white d-md-flex d-none"><i class="fa fa-chevron-left"></i></div>
                             </div>
                         </div>
                     </div>
@@ -282,8 +282,8 @@
                                     </a>
                                     <?php endif; ?>
                                 </div>
-                                <div class="swiper-product-button-next swiper-button-next"><i class="fa-solid fa-chevron-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa-solid fa-chevron-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next"><i class="fa fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa fa-chevron-left"></i></div>
                             </div>
                         </div>
                     </div>
@@ -322,7 +322,7 @@
                                             <input type="hidden" name="action" value="add">
                                             <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                             <input type="hidden" name="quantity" value="1">
-                                            <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+                                            <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
                                         </form>
                                         <?php endif; ?>
                                         <?php if ($showAsk): ?>
@@ -330,10 +330,10 @@
                                         $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código:' . $garment['unique_code'];
                                         $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                         ?>
-                                        <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+                                        <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                         <?php endif; ?>
                                         <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                        <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
+                                        <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa fa-eye"></i></a>
                                     </div>
                                 </div>
                         </div>

--- a/app/views/layout/footer.php
+++ b/app/views/layout/footer.php
@@ -14,12 +14,12 @@
                             </ul>
   <!-- Soclial Link Start -->
                             <div class="widget-social justify-content-start mt-4">
-                                <a title="Facebook" href="https://www.facebook.com/profile.php?id=61572711940782&rdid=6iK3kNGxVw8jsvas&share_url=https%3A%2F%2Fwww.facebook.com%2Fshare%2F16ycGT38T3%2F"><i class="fa fa-facebook-f"></i></a>
+                                <a title="Facebook" href="https://www.facebook.com/profile.php?id=61572711940782&rdid=6iK3kNGxVw8jsvas&share_url=https%3A%2F%2Fwww.facebook.com%2Fshare%2F16ycGT38T3%2F"><i class="fa-brands fa-facebook-f"></i></a>
                                 <!-- Soclial Link Start 
-                                <a title="Twitter" href="#"><i class="fa fa-twitter"></i></a>
-                                <a title="Linkedin" href="#"><i class="fa fa-linkedin"></i></a>
-                                <a title="Youtube" href="#"><i class="fa fa-youtube"></i></a>
-                                <a title="Vimeo" href="#"><i class="fa fa-vimeo"></i></a>
+                                <a title="Twitter" href="#"><i class="fa-brands fa-twitter"></i></a>
+                                <a title="Linkedin" href="#"><i class="fa-brands fa-linkedin"></i></a>
+                                <a title="Youtube" href="#"><i class="fa-brands fa-youtube"></i></a>
+                                <a title="Vimeo" href="#"><i class="fa-brands fa-vimeo"></i></a>
                                 -->
                             </div>
 
@@ -106,7 +106,7 @@
                 <div class="row align-items-center">
                     <div class="col-12 text-center">
                         <div class="copyright-content">
-                            <p class="mb-0">© 2025 <strong>El Armario </strong> del ahorro <i class="fa fa-heart text-danger"></i> Sitio creado por <a href="https://interweb.com.ec/">InterWEB.</a></p>
+                            <p class="mb-0">© 2025 <strong>El Armario </strong> del ahorro <i class="fa-solid fa-heart text-danger"></i> Sitio creado por <a href="https://interweb.com.ec/">InterWEB.</a></p>
                         </div>
                     </div>
                 </div>
@@ -118,8 +118,8 @@
     
         <!-- Scroll Top Start -->
         <a href="#" class="scroll-top" id="scroll-top">
-            <i class="arrow-top fa fa-long-arrow-up"></i>
-            <i class="arrow-bottom fa fa-long-arrow-up"></i>
+            <i class="arrow-top fa-solid fa-arrow-up-long"></i>
+            <i class="arrow-bottom fa-solid fa-arrow-up-long"></i>
         </a>
         <!-- Scroll Top End -->
         <!-- Cart Modal Start -->

--- a/app/views/layout/footer.php
+++ b/app/views/layout/footer.php
@@ -14,12 +14,12 @@
                             </ul>
   <!-- Soclial Link Start -->
                             <div class="widget-social justify-content-start mt-4">
-                                <a title="Facebook" href="https://www.facebook.com/profile.php?id=61572711940782&rdid=6iK3kNGxVw8jsvas&share_url=https%3A%2F%2Fwww.facebook.com%2Fshare%2F16ycGT38T3%2F"><i class="fa-brands fa-facebook-f"></i></a>
+                                <a title="Facebook" href="https://www.facebook.com/profile.php?id=61572711940782&rdid=6iK3kNGxVw8jsvas&share_url=https%3A%2F%2Fwww.facebook.com%2Fshare%2F16ycGT38T3%2F"><i class="fa fa-facebook"></i></a>
                                 <!-- Soclial Link Start 
-                                <a title="Twitter" href="#"><i class="fa-brands fa-twitter"></i></a>
-                                <a title="Linkedin" href="#"><i class="fa-brands fa-linkedin"></i></a>
-                                <a title="Youtube" href="#"><i class="fa-brands fa-youtube"></i></a>
-                                <a title="Vimeo" href="#"><i class="fa-brands fa-vimeo"></i></a>
+                                <a title="Twitter" href="#"><i class="fa fa-twitter"></i></a>
+                                <a title="Linkedin" href="#"><i class="fa fa-linkedin"></i></a>
+                                <a title="Youtube" href="#"><i class="fa fa-youtube"></i></a>
+                                <a title="Vimeo" href="#"><i class="fa fa-vimeo"></i></a>
                                 -->
                             </div>
 
@@ -106,7 +106,7 @@
                 <div class="row align-items-center">
                     <div class="col-12 text-center">
                         <div class="copyright-content">
-                            <p class="mb-0">© 2025 <strong>El Armario </strong> del ahorro <i class="fa-solid fa-heart text-danger"></i> Sitio creado por <a href="https://interweb.com.ec/">InterWEB.</a></p>
+                            <p class="mb-0">© 2025 <strong>El Armario </strong> del ahorro <i class="fa fa-heart text-danger"></i> Sitio creado por <a href="https://interweb.com.ec/">InterWEB.</a></p>
                         </div>
                     </div>
                 </div>
@@ -118,8 +118,8 @@
     
         <!-- Scroll Top Start -->
         <a href="#" class="scroll-top" id="scroll-top">
-            <i class="arrow-top fa-solid fa-arrow-up-long"></i>
-            <i class="arrow-bottom fa-solid fa-arrow-up-long"></i>
+            <i class="arrow-top fa fa-long-arrow-up"></i>
+            <i class="arrow-bottom fa fa-long-arrow-up"></i>
         </a>
         <!-- Scroll Top End -->
         <!-- Cart Modal Start -->

--- a/app/views/layout/header.php
+++ b/app/views/layout/header.php
@@ -16,15 +16,11 @@ echo "<!DOCTYPE html>\n";
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>El armario del ahorro</title>    
     <link rel="icon" href="./assets/favicon.ico">
-    <link rel="preload" href="./assets/fonts/fontAwesome/fontawesome-webfont.woff2" as="font" type="font/woff2" crossorigin>
-
     <link rel="icon" href="<?= asset('assets/favicon.ico') ?>">
-    <link rel="preload" href="<?= asset('assets/fonts/fontAwesome/fontawesome-webfont.woff2?v=4.7.0') ?>" as="font" type="font/woff2" crossorigin>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="stylesheet" href="<?= asset('assets/css/vendor/fontawesome.min.css') ?>">
-    <link rel="stylesheet" href="<?= asset('assets/css/vendor/pe-icon-7-stroke.min.css') ?>">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-+s1xgWZld0dfzpOwLKhPNgm6kKiC9JIhbnoAVnX1nvUs9f7oOJPfm6D/Ejko116IhVQbKXtEOi33ECszO2vCNA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="<?= asset('assets/css/plugins/swiper-bundle.min.css') ?>" />
     <link rel="stylesheet" href="<?= asset('assets/css/plugins/animate.min.css') ?>" />
     <link rel="stylesheet" href="<?= asset('assets/css/plugins/aos.min.css') ?>" />
@@ -90,13 +86,13 @@ echo "<!DOCTYPE html>\n";
                         <div class="col-xl-2 col-6">
                             <div class="header-actions">
                                 <a href="<?= asset('cart.php') ?>" class="header-action-btn header-action-btn-cart">
-                                    <i class="fa fa-cart-plus"></i>
+                                    <i class="fa-solid fa-cart-plus"></i>
                                     <span class="header-action-num"><?= htmlspecialchars((string)$cartCount, ENT_QUOTES, 'UTF-8') ?></span>
                                 </a>
 
                                 <!-- Mobile Menu Hambarger Action Button Start -->
                                 <a href="javascript:void(0)" class="header-action-btn header-action-btn-menu d-xl-none d-lg-block">
-                                    <i class="fa fa-bars"></i>
+                                    <i class="fa-solid fa-bars"></i>
                                 </a>
                                 <!-- Mobile Menu Hambarger Action Button End -->
 
@@ -119,7 +115,7 @@ echo "<!DOCTYPE html>\n";
 
                 <!-- Button Close Start -->
                 <div class="offcanvas-btn-close">
-                    <i class="pe-7s-close"></i>
+                    <i class="fa-solid fa-xmark"></i>
                 </div>
                 <!-- Button Close End -->
 
@@ -137,19 +133,19 @@ echo "<!DOCTYPE html>\n";
 
                     <!-- Contact Links Start -->
                     <ul class="contact-links">
-                        <li><i class="fa fa-phone"></i><a href="whatsapp://send?phone=593989818620"> +593 989 818 620</a></li>
-                        <li><i class="fa fa-calendar"></i> <span>Lunes - Viernes 17:00 - 20:00</span> </li>
-                        <li><i class="fa fa-calendar"></i> <span>Sábados - Domingos 09:00 - 20:00</span> </li>
+                        <li><i class="fa-solid fa-phone"></i><a href="whatsapp://send?phone=593989818620"> +593 989 818 620</a></li>
+                        <li><i class="fa-solid fa-calendar"></i> <span>Lunes - Viernes 17:00 - 20:00</span> </li>
+                        <li><i class="fa-solid fa-calendar"></i> <span>Sábados - Domingos 09:00 - 20:00</span> </li>
                     </ul>
                     <!-- Contact Links End -->
 
                     <!-- Social Widget Start -->
                     <div class="widget-social">
-                        <a title="Facebook" href="#"><i class="fa fa-facebook-f"></i></a>
-                        <a title="Twitter" href="#"><i class="fa fa-twitter"></i></a>
-                        <a title="Linkedin" href="#"><i class="fa fa-linkedin"></i></a>
-                        <a title="Youtube" href="#"><i class="fa fa-youtube"></i></a>
-                        <a title="Vimeo" href="#"><i class="fa fa-vimeo"></i></a>
+                        <a title="Facebook" href="#"><i class="fa-brands fa-facebook-f"></i></a>
+                        <a title="Twitter" href="#"><i class="fa-brands fa-twitter"></i></a>
+                        <a title="Linkedin" href="#"><i class="fa-brands fa-linkedin"></i></a>
+                        <a title="Youtube" href="#"><i class="fa-brands fa-youtube"></i></a>
+                        <a title="Vimeo" href="#"><i class="fa-brands fa-vimeo"></i></a>
                     </div>
                     <!-- Social Widget Ende -->
                 </div>

--- a/app/views/layout/header.php
+++ b/app/views/layout/header.php
@@ -20,7 +20,7 @@ echo "<!DOCTYPE html>\n";
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-+s1xgWZld0dfzpOwLKhPNgm6kKiC9JIhbnoAVnX1nvUs9f7oOJPfm6D/Ejko116IhVQbKXtEOi33ECszO2vCNA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="<?= asset('assets/css/vendor/fontawesome.min.css') ?>" />
     <link rel="stylesheet" href="<?= asset('assets/css/plugins/swiper-bundle.min.css') ?>" />
     <link rel="stylesheet" href="<?= asset('assets/css/plugins/animate.min.css') ?>" />
     <link rel="stylesheet" href="<?= asset('assets/css/plugins/aos.min.css') ?>" />
@@ -86,13 +86,13 @@ echo "<!DOCTYPE html>\n";
                         <div class="col-xl-2 col-6">
                             <div class="header-actions">
                                 <a href="<?= asset('cart.php') ?>" class="header-action-btn header-action-btn-cart">
-                                    <i class="fa-solid fa-cart-plus"></i>
+                                    <i class="fa fa-cart-plus"></i>
                                     <span class="header-action-num"><?= htmlspecialchars((string)$cartCount, ENT_QUOTES, 'UTF-8') ?></span>
                                 </a>
 
                                 <!-- Mobile Menu Hambarger Action Button Start -->
                                 <a href="javascript:void(0)" class="header-action-btn header-action-btn-menu d-xl-none d-lg-block">
-                                    <i class="fa-solid fa-bars"></i>
+                                    <i class="fa fa-bars"></i>
                                 </a>
                                 <!-- Mobile Menu Hambarger Action Button End -->
 
@@ -115,7 +115,7 @@ echo "<!DOCTYPE html>\n";
 
                 <!-- Button Close Start -->
                 <div class="offcanvas-btn-close">
-                    <i class="fa-solid fa-xmark"></i>
+                    <i class="fa fa-times"></i>
                 </div>
                 <!-- Button Close End -->
 
@@ -133,19 +133,19 @@ echo "<!DOCTYPE html>\n";
 
                     <!-- Contact Links Start -->
                     <ul class="contact-links">
-                        <li><i class="fa-solid fa-phone"></i><a href="whatsapp://send?phone=593989818620"> +593 989 818 620</a></li>
-                        <li><i class="fa-solid fa-calendar"></i> <span>Lunes - Viernes 17:00 - 20:00</span> </li>
-                        <li><i class="fa-solid fa-calendar"></i> <span>Sábados - Domingos 09:00 - 20:00</span> </li>
+                        <li><i class="fa fa-phone"></i><a href="whatsapp://send?phone=593989818620"> +593 989 818 620</a></li>
+                        <li><i class="fa fa-calendar"></i> <span>Lunes - Viernes 17:00 - 20:00</span> </li>
+                        <li><i class="fa fa-calendar"></i> <span>Sábados - Domingos 09:00 - 20:00</span> </li>
                     </ul>
                     <!-- Contact Links End -->
 
                     <!-- Social Widget Start -->
                     <div class="widget-social">
-                        <a title="Facebook" href="#"><i class="fa-brands fa-facebook-f"></i></a>
-                        <a title="Twitter" href="#"><i class="fa-brands fa-twitter"></i></a>
-                        <a title="Linkedin" href="#"><i class="fa-brands fa-linkedin"></i></a>
-                        <a title="Youtube" href="#"><i class="fa-brands fa-youtube"></i></a>
-                        <a title="Vimeo" href="#"><i class="fa-brands fa-vimeo"></i></a>
+                        <a title="Facebook" href="#"><i class="fa fa-facebook"></i></a>
+                        <a title="Twitter" href="#"><i class="fa fa-twitter"></i></a>
+                        <a title="Linkedin" href="#"><i class="fa fa-linkedin"></i></a>
+                        <a title="Youtube" href="#"><i class="fa fa-youtube"></i></a>
+                        <a title="Vimeo" href="#"><i class="fa fa-vimeo"></i></a>
                     </div>
                     <!-- Social Widget Ende -->
                 </div>

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -76,8 +76,8 @@
                             </form>
                         </div>
                         <div class="shop_toolbar_btn">
-                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa-solid fa-table-cells"></i></button>
-                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa-solid fa-list"></i></button>
+                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa fa-th"></i></button>
+                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa fa-list"></i></button>
                         </div>
                     </div>
                     <!-- Shopt Top Bar Right End -->
@@ -103,7 +103,7 @@
                                 </span>
                                 <?php endif; ?>
                                 <div class="actions">
-                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
+                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa fa-search"></i></a>
                                 </div>
                             </div>
                             <div class="content">
@@ -144,7 +144,7 @@
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -152,10 +152,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?> 
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa fa-eye"></i></a>
                                 </div>
                             </div>
                         </div>
@@ -314,8 +314,8 @@
                                     <?php endif; ?>
                                 </div>
                                 <!-- Next Previous Button Start -->
-                                <div class="swiper-product-button-next swiper-button-next"><i class="fa-solid fa-chevron-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa-solid fa-chevron-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next"><i class="fa fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa fa-chevron-left"></i></div>
                                 <!-- Next Previous Button End -->
                             </div>
                             <!-- Single Product Image End -->
@@ -382,7 +382,7 @@
                                         <input type="hidden" name="action" value="add">
                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                       <input type="hidden" name="quantity" value="1">
-                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -390,10 +390,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
+                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa fa-eye"></i></a>
                                   </div>
                               </div>
                               <!-- Cart & Wishlist Button End -->

--- a/app/views/nueva.php
+++ b/app/views/nueva.php
@@ -76,8 +76,8 @@
                             </form>
                         </div>
                         <div class="shop_toolbar_btn">
-                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa fa-th"></i></button>
-                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa fa-th-list"></i></button>
+                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa-solid fa-table-cells"></i></button>
+                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa-solid fa-list"></i></button>
                         </div>
                     </div>
                     <!-- Shopt Top Bar Right End -->
@@ -103,7 +103,7 @@
                                 </span>
                                 <?php endif; ?>
                                 <div class="actions">
-                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="pe-7s-search"></i></a>
+                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
                                 </div>
                             </div>
                             <div class="content">
@@ -144,7 +144,7 @@
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -152,10 +152,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
                                     <?php endif; ?> 
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="pe-7s-look"></i></a>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
                                 </div>
                             </div>
                         </div>
@@ -314,8 +314,8 @@
                                     <?php endif; ?>
                                 </div>
                                 <!-- Next Previous Button Start -->
-                                <div class="swiper-product-button-next swiper-button-next"><i class="pe-7s-angle-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev"><i class="pe-7s-angle-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next"><i class="fa-solid fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa-solid fa-chevron-left"></i></div>
                                 <!-- Next Previous Button End -->
                             </div>
                             <!-- Single Product Image End -->
@@ -382,7 +382,7 @@
                                         <input type="hidden" name="action" value="add">
                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                       <input type="hidden" name="quantity" value="1">
-                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -390,10 +390,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
                                     <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="pe-7s-look"></i></a>
+                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
                                   </div>
                               </div>
                               <!-- Cart & Wishlist Button End -->

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -47,19 +47,19 @@
             <td><?= htmlspecialchars($order['payment_method'], ENT_QUOTES, 'UTF-8'); ?></td>
             <td class="text-center">
               <?php
-                $iconClass = 'fa-solid fa-clock text-warning';
+                $iconClass = 'fa fa-clock-o text-warning';
                 $orden= 'Pedido Pendiente';
                 if ($order['status'] === 'confirmed') {
-                    $iconClass = 'fa-solid fa-check text-success';
+                    $iconClass = 'fa fa-check text-success';
                     $orden= 'Pedido Confirmado';
                 } elseif ($order['status'] === 'credit') {
-                    $iconClass = 'fa-solid fa-wallet text-info';
+                    $iconClass = 'fa fa-credit-card text-info';
                     $orden= 'Pedido a crédito';
                 } elseif ($order['status'] === 'paid') {
-                    $iconClass = 'fa-solid fa-money-bill-wave text-primary';
+                    $iconClass = 'fa fa-money text-primary';
                     $orden= 'Pedido Pagado';
                 } elseif ($order['status'] === 'rejected') {
-                    $iconClass = 'fa-solid fa-circle-xmark text-danger';
+                    $iconClass = 'fa fa-times-circle text-danger';
                     $orden= 'Pedido Rechazado';
                 }
               ?>

--- a/app/views/pedidos.php
+++ b/app/views/pedidos.php
@@ -47,19 +47,19 @@
             <td><?= htmlspecialchars($order['payment_method'], ENT_QUOTES, 'UTF-8'); ?></td>
             <td class="text-center">
               <?php
-                $iconClass = 'pe-7s-clock text-warning';
+                $iconClass = 'fa-solid fa-clock text-warning';
                 $orden= 'Pedido Pendiente';
                 if ($order['status'] === 'confirmed') {
-                    $iconClass = 'pe-7s-check text-success';
+                    $iconClass = 'fa-solid fa-check text-success';
                     $orden= 'Pedido Confirmado';
                 } elseif ($order['status'] === 'credit') {
-                    $iconClass = 'pe-7s-wallet text-info';
+                    $iconClass = 'fa-solid fa-wallet text-info';
                     $orden= 'Pedido a crédito';
                 } elseif ($order['status'] === 'paid') {
-                    $iconClass = 'pe-7s-cash text-primary';
+                    $iconClass = 'fa-solid fa-money-bill-wave text-primary';
                     $orden= 'Pedido Pagado';
                 } elseif ($order['status'] === 'rejected') {
-                    $iconClass = 'pe-7s-close-circle text-danger';
+                    $iconClass = 'fa-solid fa-circle-xmark text-danger';
                     $orden= 'Pedido Rechazado';
                 }
               ?>

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -35,14 +35,14 @@
           $showAsk  = $tag !== 'vendido';
         ?>
         <?php if ($showAsk): ?>
-        <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-success" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+        <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-success" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
         <?php endif; ?>
         <?php if ($showCart): ?>
         <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="mt-3">
           <input type="hidden" name="action" value="add">
           <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
           <input type="hidden" name="quantity" value="1">
-          <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+          <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
         </form>
         <?php endif; ?>
       </div>

--- a/app/views/prenda_detalle.php
+++ b/app/views/prenda_detalle.php
@@ -35,14 +35,14 @@
           $showAsk  = $tag !== 'vendido';
         ?>
         <?php if ($showAsk): ?>
-        <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-success" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+        <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-success" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
         <?php endif; ?>
         <?php if ($showCart): ?>
         <form method="post" action="<?= htmlspecialchars(asset('cart.php'), ENT_QUOTES, 'UTF-8'); ?>" class="mt-3">
           <input type="hidden" name="action" value="add">
           <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
           <input type="hidden" name="quantity" value="1">
-          <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+          <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
         </form>
         <?php endif; ?>
       </div>

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -76,8 +76,8 @@
                             </form>
                         </div>
                         <div class="shop_toolbar_btn">
-                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa fa-th"></i></button>
-                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa fa-th-list"></i></button>
+                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa-solid fa-table-cells"></i></button>
+                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa-solid fa-list"></i></button>
                         </div>
                     </div>
                     <!-- Shopt Top Bar Right End -->
@@ -103,7 +103,7 @@
                                 </span>
                                 <?php endif; ?>
                                 <div class="actions">
-                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="pe-7s-search"></i></a>
+                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
                                 </div>
                             </div>
                             <div class="content">
@@ -144,7 +144,7 @@
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -152,10 +152,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
                                     <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="pe-7s-look"></i></a>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
                                 </div>
                             </div>
                         </div>
@@ -314,8 +314,8 @@
                                     <?php endif; ?>
                                 </div>
                                 <!-- Next Previous Button Start -->
-                                <div class="swiper-product-button-next swiper-button-next"><i class="pe-7s-angle-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev"><i class="pe-7s-angle-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next"><i class="fa-solid fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa-solid fa-chevron-left"></i></div>
                                 <!-- Next Previous Button End -->
                             </div>
                             <!-- Single Product Image End -->
@@ -382,7 +382,7 @@
                                         <input type="hidden" name="action" value="add">
                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                       <input type="hidden" name="quantity" value="1">
-                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
+                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -390,10 +390,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
+                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
                                     <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="pe-7s-look"></i></a>
+                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
                                   </div>
                               </div>
                               <!-- Cart & Wishlist Button End -->

--- a/app/views/usada.php
+++ b/app/views/usada.php
@@ -76,8 +76,8 @@
                             </form>
                         </div>
                         <div class="shop_toolbar_btn">
-                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa-solid fa-table-cells"></i></button>
-                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa-solid fa-list"></i></button>
+                            <button data-role="grid_3" type="button" class="active btn-grid-4" title="Grid"><i class="fa fa-th"></i></button>
+                            <button data-role="grid_list" type="button" class="btn-list" title="List"><i class="fa fa-list"></i></button>
                         </div>
                     </div>
                     <!-- Shopt Top Bar Right End -->
@@ -103,7 +103,7 @@
                                 </span>
                                 <?php endif; ?>
                                 <div class="actions">
-                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa-solid fa-magnifying-glass"></i></a>
+                                    <a href="#" title="Quickview" class="action quickview" data-bs-toggle="modal" data-bs-target="#quickview-<?= $garment['id']; ?>"><i class="fa fa-search"></i></a>
                                 </div>
                             </div>
                             <div class="content">
@@ -144,7 +144,7 @@
                                         <input type="hidden" name="action" value="add">
                                         <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                         <input type="hidden" name="quantity" value="1">
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -152,10 +152,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+                                    <a href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-success ms-1" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
+                                    <a href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" class="btn btn-sm btn-secondary btn-hover-primary ms-1" title="Ver detalles"><i class="fa fa-eye"></i></a>
                                 </div>
                             </div>
                         </div>
@@ -314,8 +314,8 @@
                                     <?php endif; ?>
                                 </div>
                                 <!-- Next Previous Button Start -->
-                                <div class="swiper-product-button-next swiper-button-next"><i class="fa-solid fa-chevron-right"></i></div>
-                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa-solid fa-chevron-left"></i></div>
+                                <div class="swiper-product-button-next swiper-button-next"><i class="fa fa-chevron-right"></i></div>
+                                <div class="swiper-product-button-prev swiper-button-prev"><i class="fa fa-chevron-left"></i></div>
                                 <!-- Next Previous Button End -->
                             </div>
                             <!-- Single Product Image End -->
@@ -382,7 +382,7 @@
                                         <input type="hidden" name="action" value="add">
                                       <input type="hidden" name="id" value="<?= (int)$garment['id']; ?>">
                                       <input type="hidden" name="quantity" value="1">
-                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa-solid fa-cart-plus"></i></button>
+                                      <button type="submit" class="btn btn-outline-danger" title="Agregar al carrito"><i class="fa fa-cart-plus"></i></button>
                                     </form>
                                     <?php endif; ?>
                                     <?php if ($showAsk): ?>
@@ -390,10 +390,10 @@
                                     $waMessage = 'Por favor necesito  información de la prenda ' . $garment['name'] . ' de código: ' . $garment['unique_code'];
                                     $waLink = 'https://wa.me/593999591820?text=' . urlencode($waMessage);
                                     ?>
-                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa-brands fa-whatsapp"></i></a>
+                                    <a class="btn btn-success ms-1" href="<?= htmlspecialchars($waLink, ENT_QUOTES, 'UTF-8'); ?>" title="Preguntar por esta prenda"><i class="fa fa-whatsapp"></i></a>
                                     <?php endif; ?>
                                     <?php $detailUrl = asset('prenda.php') . '?id=' . urlencode((string)$garment['id']); ?>
-                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa-solid fa-eye"></i></a>
+                                    <a class="btn btn-secondary btn-hover-primary ms-1" href="<?= htmlspecialchars($detailUrl, ENT_QUOTES, 'UTF-8'); ?>" title="Ver detalles"><i class="fa fa-eye"></i></a>
                                   </div>
                               </div>
                               <!-- Cart & Wishlist Button End -->


### PR DESCRIPTION
## Summary
- replace the legacy icon font includes with the Font Awesome CDN and update header/menu icons
- swap all remaining icon usages in the storefront views to their Font Awesome equivalents
- refresh order status, action buttons, and social icons to rely on the new icon set

## Testing
- php -l app/views/cart.php app/views/home.php app/views/layout/footer.php app/views/layout/header.php app/views/nueva.php app/views/pedidos.php app/views/prenda_detalle.php app/views/usada.php

------
https://chatgpt.com/codex/tasks/task_b_68cca94a68cc8326800bf5a45aa8ce8f